### PR TITLE
Add arrival times

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,14 @@
+# Build files
+/build/
+/src/cr_pulse_interpolator.egg-info/
+
+# Demo files
+/demo/*.h5
+/demo/sample_data.txt
+
+# Virtual environemnts
+*venv*/
+
+# Project settings
+
+.idea/

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 Full electric-field waveform interpolation for air shower simulations
 
 For elaborate information on the methods and their performance, see  
-Corstanje et al. (2023), arXiv **2306.13514**  
+Corstanje et al. (2023), JINST 18 P09005, arXiv **2306.13514**  
 Please cite this when using code and/or method in your analysis, publication etc.
 
 ## Contents

--- a/demo/minimal_usage_demo.py
+++ b/demo/minimal_usage_demo.py
@@ -48,7 +48,7 @@ Return shape is (Nsamples, Npol)
 Optionally, it can be low-pass filtered to an estimated reliable cutoff frequency
 This is a reliable yet sometimes overly conservative estimate up to which frequency the interpolation is accurate
 """
-interpolated_pulse, timings, _, _ = signal_interpolator(this_x, this_y,full_output=True)
+interpolated_pulse, timings, _, _ = signal_interpolator(this_x, this_y, full_output=True)
 
 """
 Because the trace start times were not provided during the interpolator initialisation, the returned timings

--- a/src/cr_pulse_interpolator/interpolation_fourier.py
+++ b/src/cr_pulse_interpolator/interpolation_fourier.py
@@ -1,5 +1,8 @@
 # Module for Fourier interpolation of 2D functions sampled on a polar grid
 # Author: A. Corstanje (a.corstanje@astro.ru.nl), 2020 - 2023
+#
+# See article: A. Corstanje et al. 2023, JINST 18 P09005, arXiv 2306.13514, doi 10.1088/1748-0221/18/09/P09005 
+# Please cite this when using code and/or methods in your analysis
 
 import numpy as np
 import scipy.interpolate as intp
@@ -17,11 +20,9 @@ class interp2d_fourier:
 
         radius = np.sqrt(x**2 + y**2)
         phi = np.arctan2(y, x) # uses interval -pi..pi
-        phi = np.deg2rad(np.around(np.rad2deg(phi)))
-        phi[np.abs(phi) < np.deg2rad(0.01)] = 0.0 # avoid pathology
-        phi[phi<0] += 2*np.pi # put into 0..2pi for ordering
-        phi_sorting = np.argsort(phi)
 
+        phi[phi<0] += 2*np.pi # put into 0..2pi for ordering.        
+        phi_sorting = np.argsort(phi)
         # Assume star-shaped pattern, i.e. radial # steps = number of (almost) identical phi-values
         # May not work very near (0, 0)
         self._phi0 = phi[phi_sorting][0]
@@ -30,7 +31,6 @@ class interp2d_fourier:
         radial_steps = len(np.where(np.abs(test) < 0.0001)[0])
         phi_steps = len(phi_sorting) // radial_steps
         phi_sorting = phi_sorting.reshape((phi_steps, radial_steps))
-
         indices = np.argsort(radius[phi_sorting], axis=1)
         for i in range(phi_steps): # Sort by radius; should be possible without for-loop...
             phi_sorting[i] = phi_sorting[i][indices[i]]

--- a/src/cr_pulse_interpolator/signal_interpolation_fourier.py
+++ b/src/cr_pulse_interpolator/signal_interpolation_fourier.py
@@ -489,7 +489,7 @@ class interp2d_signal:
 
     def __call__(self, x, y,
                  lowfreq=30.0, highfreq=500.0, filter_up_to_cutoff=False,
-                 account_for_timing=True, return_arrival_times=False, pulse_centered=False,
+                 account_for_timing=True, pulse_centered=True,
                  const_time_offset=20.0e-9, full_output=False):
         """
         Call the object, which computes the interpolation at arbitrary position (x, y)
@@ -501,14 +501,18 @@ class interp2d_signal:
         lowfreq : low-frequency limit for bandpass filtering of interpolated pulse, default 30.0 MHz
         highfreq : high-frequency limit, idem, default 500.0 MHz
         filter_up_to_cutoff : set to True for low-pass filtering up to local estimated cutoff frequency, default False
-        account_for_timing : set to False to have each pulse at a fixed time given by 'const_time_offset' instead of its natural arrival time. Default True
-        return_arrival_times : bool, default=False
-            If True, the pulses are not shifted according to their arrival times. Rather, the interpolated
-            arrival times are returned as an array. If the trace arrival times were provided during initialisation,
-            these are interpolated and accounted for as well. Note that this option is incompatible with
-            `account_for_timing` and `pulse_centered` .
-        const_time_offset : constant time offset if not using interpolated arrival times. Default 20e-9 (seconds).
-        full_output : set to True to output both time series and spectra. Default False, returns only time series.
+        account_for_timing : bool, default=True
+            When True, the pulses are offset from each other according to their natural arrival time.
+            Set to False to have each pulse at a fixed time given by `const_time_offset` instead.
+        pulse_centered : bool, default=True
+            If True, the pulses are shifted to the center of the trace, instead of being close to the trace start
+            as CoREAS simulates them. This is useful to deal with the ringing introduced by filtering the traces.
+        const_time_offset : float, default=20e-9
+            Constant time offset in seconds if not using interpolated arrival times.
+            Note that if used together with `pulse_centered`, this time offset is with respect to the center
+            of the trace.
+        full_output : bool, default=False
+            Put this to True to retrieve arrival time and spectra, next to the signal traces.
         """
         # if account_for_timing + return_arrival_times > 1:
         #     raise ValueError(f'account_for_timing and  return_arrival_times are not compatible,'
@@ -571,6 +575,25 @@ class interp2d_signal:
         else:
             raise ValueError('Unknown reconstruction method: %s' % self.method)
 
+        # Get the start time of the trace from the interpolation
+        trace_start_time = 0
+        if self.interpolators_arrival_times is not None:
+            trace_start_time += self.interpolators_arrival_times(x, y)
+        else:
+            # This should be a logging warning statement
+            print('Trace arrival times were not set during init, only relative timings are returned!')
+        if pulse_centered:
+            # We account for the time shift here, because the later loop is over all polarisations and
+            # then this operation would be applied multiple times
+            time_delta = self.trace_length * 0.5 * self.sampling_period
+            trace_start_time -= time_delta
+        if not account_for_timing:
+            # The interpolated trace start times were from before the timings are taken out from the phase
+            # So it case we do not put them back in, we need to adjust the start times
+            trace_start_time -= const_time_offset
+            print('Relative timing between polarisations is not taken into account!')
+            # TODO: could make trace_start_time array of shape (Npol) and adjust each pol for timings?
+
         # Apply the 30-80 MHz arrival times and phase constants, each interpolated to (x, y) first
         for pol in range(Npols):
             timings[pol] = self.interpolators_timing[pol](x, y)
@@ -579,17 +602,11 @@ class interp2d_signal:
             if pulse_centered:
                 # move pulse to the center of the trace
                 time_delta = self.trace_length * 0.5 * self.sampling_period
-                phase_shifts = -1.0e6*freqs * 2*np.pi * (time_delta)
+                phase_shifts = -1.0e6 * freqs * 2 * np.pi * time_delta
                 phasespectrum[:, pol] += phase_shifts
             if account_for_timing:
-                phase_shifts = -1.0e6*freqs * 2*np.pi * timings[pol]
+                phase_shifts = -1.0e6 * freqs * 2 * np.pi * timings[pol]
                 phasespectrum[:, pol] += phase_shifts
-            if return_arrival_times:
-                if self.interpolators_arrival_times is not None:
-                    toa = self.interpolators_arrival_times(x, y)
-                    timings[pol] += toa
-                else:
-                    print('Trace arrival times were not set during init, only relative timings are returned!')
             else:
                 phase_shifts = -1.0e6*freqs * 2*np.pi * const_time_offset
                 phasespectrum[:, pol] += phase_shifts
@@ -624,8 +641,6 @@ class interp2d_signal:
         timeseries = np.fft.irfft(spectrum, axis=0)
 
         if full_output:
-            return timeseries, abs_spectrum, phasespectrum, timings
-        elif return_arrival_times:
-            return timeseries, timings
+            return timeseries, trace_start_time, abs_spectrum, phasespectrum
         else:
             return timeseries


### PR DESCRIPTION
The current `account_for_timing` option only account for the relative time difference between trace samples. But when inputting traces which start at different times (as often happens with CoREAS traces), the timing differences are not correct in absolute terms anymore.

To solve this, I have added an option to provide the start times of all traces as array to the `__init__` method. This will then interpolate those, and can then later be used to return the correct trace start time when calling the interpolator. To get the start times back, one can use the `account_for_arrival_times` option when using the interpolator.