### PR TITLE
Fix demo scripts

### DIFF
--- a/demo/demo_interpolation_fourier.py
+++ b/demo/demo_interpolation_fourier.py
@@ -3,7 +3,7 @@
 
 import numpy as np
 import matplotlib.pyplot as plt
-plt.ion()
+# plt.ion()
 from matplotlib import cm
 import cr_pulse_interpolator.interpolation_fourier as interpF
 
@@ -98,15 +98,21 @@ ZI = fourier_interpolator(XI, YI)
 
 # And plot it
 maxp = np.max(ZI)
-plt.figure()
-plt.gca().pcolor(XI, YI, ZI, vmax=maxp, vmin=0, cmap=cm.jet)
-plt.scatter(x, y, marker='+', s=3, color='w')
+fig, ax = plt.subplots()
+
+ax.pcolor(XI, YI, ZI, vmax=maxp, vmin=0, cmap=cm.jet)
+ax.scatter(x, y, marker='+', s=3, color='w')
+
 mm = cm.ScalarMappable(cmap=cm.jet)
 mm.set_array([0.0, maxp])
-cbar = plt.colorbar(mm)
+
+cbar = fig.colorbar(mm, ax=ax)
 cbar.set_label('Values of f(x, y)')
-plt.xlabel('x [ m ]')
-plt.ylabel('y [ m ]')
-plt.xlim(-250, 250)
-plt.ylim(-250, 250)
-plt.gca().set_aspect('equal')
+
+ax.set_xlabel('x [ m ]')
+ax.set_ylabel('y [ m ]')
+ax.set_xlim(-250, 250)
+ax.set_ylim(-250, 250)
+ax.set_aspect('equal')
+
+plt.show()

--- a/src/cr_pulse_interpolator/interpolation_fourier.py
+++ b/src/cr_pulse_interpolator/interpolation_fourier.py
@@ -19,9 +19,9 @@ class interp2d_fourier:
         """
 
         radius = np.sqrt(x**2 + y**2)
-        phi = np.arctan2(y, x) # uses interval -pi..pi
-
-        phi[phi<0] += 2*np.pi # put into 0..2pi for ordering.        
+        phi = np.arctan2(y, x)  # uses interval -pi..pi
+        phi = np.around(phi, 15)  # based on observation that offsets from 0 up to 1e-16 can result from arctan2
+        phi[phi<0] += 2*np.pi  # put into 0..2pi for ordering.
         phi_sorting = np.argsort(phi)
         # Assume star-shaped pattern, i.e. radial # steps = number of (almost) identical phi-values
         # May not work very near (0, 0)


### PR DESCRIPTION
The changes from #11 broke the demo scripts, due to some values from `np.arctan2()` being very small but negative. This would result in these values being increased with 2 pi in the following lines in `get_ordering_indices()`, which messes up the ordering.

Here I reintroduce the rounding again, but much less aggressive than before. The rounding is small enough that it does not reintroduce #10 again.