### PR TITLE
Make extrapolation in signal interpolation optional

### DIFF
--- a/src/cr_pulse_interpolator/interpolation_fourier.py
+++ b/src/cr_pulse_interpolator/interpolation_fourier.py
@@ -7,6 +7,7 @@
 import numpy as np
 import scipy.interpolate as intp
 
+
 class interp2d_fourier:
     @classmethod
     def get_ordering_indices(self, x, y):
@@ -18,23 +19,23 @@ class interp2d_fourier:
         y : 1D array of y positions
         """
 
-        radius = np.sqrt(x**2 + y**2)
+        radius = np.sqrt(x ** 2 + y ** 2)
         phi = np.arctan2(y, x)  # uses interval -pi..pi
         phi = np.around(phi, 15)  # based on observation that offsets from 0 up to 1e-16 can result from arctan2
-        phi[phi<0] += 2*np.pi  # put into 0..2pi for ordering.
+        phi[phi < 0] += 2 * np.pi  # put into 0..2pi for ordering.
         phi_sorting = np.argsort(phi)
         # Assume star-shaped pattern, i.e. radial # steps = number of (almost) identical phi-values
         # May not work very near (0, 0)
         self._phi0 = phi[phi_sorting][0]
-        #print('Phi0 = %1.8f' % self._phi0)
+
         test = phi[phi_sorting] - self._phi0
         radial_steps = len(np.where(np.abs(test) < 0.0001)[0])
         phi_steps = len(phi_sorting) // radial_steps
         phi_sorting = phi_sorting.reshape((phi_steps, radial_steps))
         indices = np.argsort(radius[phi_sorting], axis=1)
-        for i in range(phi_steps): # Sort by radius; should be possible without for-loop...
+        for i in range(phi_steps):  # Sort by radius; should be possible without for-loop...
             phi_sorting[i] = phi_sorting[i][indices[i]]
-        ordering_indices = phi_sorting.T # get shape (radial_steps, phi_steps)
+        ordering_indices = phi_sorting.T  # get shape (radial_steps, phi_steps)
 
         return ordering_indices
 
@@ -44,28 +45,33 @@ class interp2d_fourier:
         Convert complex FFT as from np.fft.rfft to real-valued cos, sin components
         Input: complex Fourier components, with Fourier series running along the last axis.
         """
-        cos_components = 2*np.real(fourier)
+        cos_components = 2 * np.real(fourier)
         cos_components[..., 0] *= 0.5
         cos_components[..., -1] *= 0.5
-        sin_components = -2*np.imag(fourier)
+        sin_components = -2 * np.imag(fourier)
 
         return (cos_components, sin_components)
 
     def __init__(self, x, y, values, radial_method='cubic', fill_value=None, recover_concentric_rings=False):
         """
-        # Produce a callable instance (given by the function __call__) to interpolate a function value(x, y) sampled at the input positions (x, y)
+        Produce a callable instance (given by the function __call__) to interpolate a function value(x, y)
+        sampled at the input positions (x, y)
 
         Parameters
         ----------
         x : 1D array of x positions of simulated antennas
         y : idem for y
         values : the function values (as 1D array) at positions (x, y)
-        radial_method : the interp1d method for interpolating Fourier components along the radial axis (optional, default 'cubic' i.e. cubic splines)
-        fill_value : the fill value to pass to interp1d to use for a radius outside the min..max radius interval from the input. Set to 'extrapolate' to extrapolate beyond radial limits; accuracy outside the interval is limited. Optional, default None, meaning stay constant for r < r_min, and 0 for r > r_max
-        recover_concentric_rings : set True if the grid is not purely circular-symmetric; results may not be accurate. Optional, default False
+        radial_method : the interp1d method for interpolating Fourier components along the radial axis
+        (optional, default 'cubic' i.e. cubic splines)
+        fill_value : the fill value to pass to interp1d to use for a radius outside the min..max radius interval from
+        the input. Set to 'extrapolate' to extrapolate beyond radial limits; accuracy outside the interval is limited.
+        Optional, default None, meaning stay constant for r < r_min, and 0 for r > r_max
+        recover_concentric_rings : set True if the grid is not purely circular-symmetric; results may not be accurate.
+        Optional, default False
         """
         # Convert (x, y) to (r, phi), make 2d position array, sorting positions and values by r and phi
-        radius = np.sqrt(x**2 + y**2)
+        radius = np.sqrt(x ** 2 + y ** 2)
 
         ordering_indices = self.get_ordering_indices(x, y)
         values_ordered = np.copy(values)[ordering_indices]
@@ -75,8 +81,8 @@ class interp2d_fourier:
         # Check if the radius does not vary along angular direction (with tolerance)
         if np.max(np.std(radius[ordering_indices], axis=1)) > 0.1 * np.min(radius):
             if not recover_concentric_rings:
-                raise ValueError("Radius must be (approx.) constant along angular direction." + \
-                                " You can try to \"fix\" that by using \"recover_concentric_rings=True\"")
+                raise ValueError("Radius must be (approx.) constant along angular direction. "
+                                 "You can try to \"fix\" that by using \"recover_concentric_rings=True\"")
             else:
                 self.radial_axis = np.mean(radius[ordering_indices], axis=1)
                 values_ordered_interpolated = []
@@ -89,11 +95,12 @@ class interp2d_fourier:
         # FFT over the angular direction, for each radius
         self.angular_FFT = np.fft.rfft(values_ordered, axis=1)
         length = values_ordered.shape[-1]
-        self.angular_FFT /= float(length) # normalize
+        self.angular_FFT /= float(length)  # normalize
 
         # Produce interpolator function, interpolating the FFT components as a function of radius
-        self.interpolator_radius = intp.interp1d(self.radial_axis, self.angular_FFT, axis=0, kind=radial_method, fill_value='extrapolate') # Interpolates the Fourier components along the radial axis
-
+        self.interpolator_radius = intp.interp1d(
+            self.radial_axis, self.angular_FFT, axis=0, kind=radial_method, fill_value='extrapolate'
+        )  # Interpolates the Fourier components along the radial axis
 
     def __call__(self, x, y, max_fourier_mode=None):
         """
@@ -103,9 +110,10 @@ class interp2d_fourier:
         ----------
         x : x positions as float or numpy ND array
         y : idem for y
-        max_fourier_mode : optional cutoff for spatial frequencies along circles, i.e. do Fourier sum up to (incl.) this mode. Default None i.e. do all modes
+        max_fourier_mode : optional cutoff for spatial frequencies along circles, i.e. do Fourier sum up to (incl.)
+        this mode. Default None i.e. do all modes
         """
-        radius = np.sqrt(x**2 + y**2)
+        radius = np.sqrt(x ** 2 + y ** 2)
         phi = np.arctan2(y, x) - self._phi0
 
         # Interpolate Fourier components over all values of radius
@@ -114,14 +122,18 @@ class interp2d_fourier:
 
         (cos_components, sin_components) = interp2d_fourier.cos_sin_components(fourier)
 
-        limit = max_fourier_mode+1 if max_fourier_mode is not None else fourier_len
-        mult = np.linspace(0, limit-1, limit).astype(int) # multipliers for Fourier modes, as k in cos(k*phi), sin(k*phi)
+        # Multipliers for Fourier modes, as k in cos(k*phi), sin(k*phi)
+        limit = max_fourier_mode + 1 if max_fourier_mode is not None else fourier_len
+        mult = np.linspace(0, limit - 1, limit).astype(int)
+
+        # The Fourier sum done explicitly, as sum_k( c_k cos(k phi) + s_k sin(k phi) )
         result = np.zeros_like(radius)
         if isinstance(phi, float):
-            result = np.sum(cos_components[..., 0:limit] * np.cos(phi * mult)) + np.sum(sin_components[..., 0:limit] * np.sin(phi * mult))
+            result += np.sum(cos_components[..., 0:limit] * np.cos(phi * mult))
+            result += np.sum(sin_components[..., 0:limit] * np.sin(phi * mult))
         else:
-            result = np.sum(cos_components[..., 0:limit] * np.cos(phi[..., np.newaxis] * mult), axis=-1) + np.sum(sin_components[..., 0:limit] * np.sin(phi[..., np.newaxis] * mult), axis=-1)
-        # The Fourier sum done explicitly, as sum_k( c_k cos(k phi) + s_k sin(k phi) )
+            result += np.sum(cos_components[..., 0:limit] * np.cos(phi[..., np.newaxis] * mult), axis=-1)
+            result += np.sum(sin_components[..., 0:limit] * np.sin(phi[..., np.newaxis] * mult), axis=-1)
 
         return result
 

--- a/src/cr_pulse_interpolator/interpolation_fourier.py
+++ b/src/cr_pulse_interpolator/interpolation_fourier.py
@@ -26,7 +26,7 @@ class interp2d_fourier:
     fill_value : array-like or (array-like, array_like) or “extrapolate”, default='extrapolate'
         the fill value to pass to interp1d to use for a radius outside the min..max radius interval from
         the input. Set to 'extrapolate' to extrapolate beyond radial limits; accuracy outside the interval is limited.
-        Optional, default None, meaning stay constant for r < r_min, and 0 for r > r_max
+        If set to None, the `fill_value` is set such the output is constant for r < r_min, and 0 for r > r_max.
     recover_concentric_rings : bool, default=False
         set True if the grid is not purely circular-symmetric; results may not be accurate.
     """
@@ -109,8 +109,10 @@ class interp2d_fourier:
         self.angular_FFT /= float(length)  # normalize
 
         # Produce interpolator function, interpolating the FFT components as a function of radius
+        if fill_value is None:
+            fill_value = (self.angular_FFT[0], np.zeros_like(self.angular_FFT[0]))
         self.interpolator_radius = intp.interp1d(
-            self.radial_axis, self.angular_FFT, axis=0, kind=radial_method, fill_value=fill_value
+            self.radial_axis, self.angular_FFT, axis=0, kind=radial_method, fill_value=fill_value, bounds_error=False
         )  # Interpolates the Fourier components along the radial axis
 
     def __call__(self, x, y, max_fourier_mode=None):

--- a/src/cr_pulse_interpolator/signal_interpolation_fourier.py
+++ b/src/cr_pulse_interpolator/signal_interpolation_fourier.py
@@ -136,11 +136,9 @@ class interp2d_signal:
             if sum_over_pol:
                 hilbert_sum_over_pol = np.sqrt(np.sum(hilbert_envelope ** 2, axis=2))
 
-                pulse_timings = (np.argmax(hilbert_sum_over_pol, axis=1) - nof_samples // 2)
-                pulse_timings *= (timestep / upsample_factor)
+                pulse_timings = (np.argmax(hilbert_sum_over_pol, axis=1) - nof_samples // 2) * (timestep / upsample_factor)
             else:
-                pulse_timings_per_pol = (np.argmax(hilbert_envelope, axis=1) - nof_samples // 2)
-                pulse_timings_per_pol *= (timestep / upsample_factor)
+                pulse_timings_per_pol = (np.argmax(hilbert_envelope, axis=1) - nof_samples // 2) * (timestep / upsample_factor)
 
         else:
             pulse_timings_per_pol = (np.argmax(signals_upsampled, axis=1) - nof_samples // 2) * (
@@ -485,10 +483,10 @@ class interp2d_signal:
         self.const_phases = self.get_constant_phases(high_freq=80.0)
 
         # Remove phase constant from phase spectra
-        self.phasespectrum_corrected -= self.const_phases[:, np.newaxis,
-                                        :]  # from (Nant, Npol) to (Nant, Nsamples, Npol)
+        self.phasespectrum_corrected -= self.const_phases[:, np.newaxis, :]  # (Nant, Npol) to (Nant, Nsamples, Npol)
         self.phasespectrum_corrected_before_freq_dependent = np.copy(
-            self.phasespectrum_corrected)  # for testing / demo purposes
+            self.phasespectrum_corrected
+        )  # for testing / demo purposes
 
         # Get degree of coherency and reliable high-cutoff frequency
         if self.verbose:

--- a/src/cr_pulse_interpolator/signal_interpolation_fourier.py
+++ b/src/cr_pulse_interpolator/signal_interpolation_fourier.py
@@ -140,6 +140,7 @@ class interp2d_signal:
             else:
                 pulse_timings_per_pol = (np.argmax(hilbert_envelope, axis=1) - nof_samples // 2) * (timestep / upsample_factor)
 
+
         else:
             pulse_timings_per_pol = (np.argmax(signals_upsampled, axis=1) - nof_samples // 2) * (
                         timestep / upsample_factor)
@@ -557,7 +558,7 @@ class interp2d_signal:
             for pol in range(Npols):
                 self.interpolators_abs_spectrum[pol, freq_channel] = interpF.interp2d_fourier(
                     x, y, self.abs_spectrum[:, freq_channel, pol],
-                    radial_method=radial_method
+                    radial_method=radial_method, fill_value=None
                 )
                 self.interpolators_freq_dependent_timing[pol, freq_channel] = interpF.interp2d_fourier(
                     x, y, self.freq_dependent_timing[:, freq_channel, pol],

--- a/src/cr_pulse_interpolator/signal_interpolation_fourier.py
+++ b/src/cr_pulse_interpolator/signal_interpolation_fourier.py
@@ -8,12 +8,14 @@ import numpy as np
 from scipy.signal import hilbert, resample
 import cr_pulse_interpolator.interpolation_fourier as interpF
 
+
 class interp2d_signal:
 
     def get_spectra(self, signals):
         """
-        # Do FFT of 'signals', assumed shape (Nants, Nsamples, Npol) i.e. the time traces are along the second axis.
-        # Produce absolute-amplitude spectrum and phase spectrum
+        Do FFT of 'signals', assumed shape (Nants, Nsamples, Npol) i.e. the time traces are along the second axis.
+        Produce absolute-amplitude spectrum and phase spectrum
+
         Parameters
         ----------
         signals : the input time traces
@@ -25,21 +27,23 @@ class interp2d_signal:
         all_antennas_spectrum = np.fft.rfft(signals, axis=1)
         abs_spectrum = np.abs(all_antennas_spectrum)
         phasespectrum = np.angle(all_antennas_spectrum)
-        unwrapped_phases = np.unwrap(phasespectrum, axis=1, discont=0.7*np.pi)
+        unwrapped_phases = np.unwrap(phasespectrum, axis=1, discont=0.7 * np.pi)
         if self.verbose:
             print('done.')
 
         freqs = np.fft.rfftfreq(Nsamples, d=self.sampling_period)
-        freqs /= 1.0e6 # in MHz
+        freqs /= 1.0e6  # in MHz
 
-        return (freqs, all_antennas_spectrum, abs_spectrum, phasespectrum, unwrapped_phases)
+        return freqs, all_antennas_spectrum, abs_spectrum, phasespectrum, unwrapped_phases
 
-    def hilbert_envelope_timing(self, signals, lowfreq=30.0, highfreq=500.0, upsample_factor=10, sum_over_pol=True, do_hilbert_envelope=True):
+    def hilbert_envelope_timing(self, signals, lowfreq=30.0, highfreq=500.0, upsample_factor=10, sum_over_pol=True,
+                                do_hilbert_envelope=True):
         """
         Produce pulse arrival times from Hilbert envelope maxima (if do_hilbert_envelope) or from raw E-field maxima.
         Assumed shape for 'signals' is (Nant, Nsamples, Npols), i.e. time traces along second axis
         Filtering is done between lowfreq and highfreq in MHz, timing is done on filtered signals (after inverse-FFT)
-        Option sum_over_pol is to sum the square of the Hilbert envelopes of each polarization, to get one arrival time over all polarizations (may help at low signal strength), default True.
+        Option sum_over_pol is to sum the square of the Hilbert envelopes of each polarization, to get one arrival time
+        over all polarizations (may help at low signal strength), default True.
 
         Parameters
         ----------
@@ -56,25 +60,27 @@ class interp2d_signal:
             print('Bandpass filtering %d to %d MHz' % (int(lowfreq), int(highfreq)))
         spectrum = np.fft.rfft(signals, axis=1)
         freqs = np.fft.rfftfreq(Nsamples, d=self.sampling_period)
-        freqs /= 1.0e6 # in MHz
-        filtering_out = np.where( (freqs < lowfreq) | (freqs > highfreq)) # or!
+        freqs /= 1.0e6  # in MHz
+        filtering_out = np.where((freqs < lowfreq) | (freqs > highfreq))  # or!
 
         spectrum[:, filtering_out, :] *= 0.0
         filtered_signals = np.fft.irfft(spectrum, axis=1)
 
         # Get strongest polarization
-        power_per_pol = np.sum(np.sum(filtered_signals**2, axis=1), axis=0)
+        power_per_pol = np.sum(np.sum(filtered_signals ** 2, axis=1), axis=0)
         strongest_pol = np.argmax(power_per_pol)
         if self.verbose:
             print('Strongest polarization is %d' % strongest_pol)
 
-        timestep = self.sampling_period # in s
+        timestep = self.sampling_period  # in s
         if self.verbose:
             print('Upsampling by a factor %d' % upsample_factor)
-        signals_upsampled = resample(filtered_signals, upsample_factor*Nsamples, axis=1)
+        signals_upsampled = resample(filtered_signals, upsample_factor * Nsamples, axis=1)
 
         nof_samples = signals_upsampled.shape[1]
-        signals_upsampled = np.roll(signals_upsampled, nof_samples//2, axis=1) # Put in the middle of the block, avoiding negative values in timing
+        signals_upsampled = np.roll(
+            signals_upsampled, nof_samples // 2, axis=1
+        )  # Put in the middle of the block, avoiding negative values in timing
 
         if do_hilbert_envelope:
             if self.verbose:
@@ -82,32 +88,34 @@ class interp2d_signal:
             hilbert_envelope = np.abs(hilbert(signals_upsampled, axis=1))
 
             if sum_over_pol:
-                hilbert_sum_over_pol = np.sqrt( np.sum(hilbert_envelope**2, axis=2) )
+                hilbert_sum_over_pol = np.sqrt(np.sum(hilbert_envelope ** 2, axis=2))
 
-                pulse_timings = (np.argmax(hilbert_sum_over_pol, axis=1) - nof_samples//2) * (timestep/upsample_factor)
+                pulse_timings = (np.argmax(hilbert_sum_over_pol, axis=1) - nof_samples // 2)
+                pulse_timings *= (timestep / upsample_factor)
             else:
-                pulse_timings_per_pol = (np.argmax(hilbert_envelope, axis=1) - nof_samples//2) * (timestep/upsample_factor)
+                pulse_timings_per_pol = (np.argmax(hilbert_envelope, axis=1) - nof_samples // 2)
+                pulse_timings_per_pol *= (timestep / upsample_factor)
 
         else:
-            pulse_timings_per_pol = (np.argmax(signals_upsampled, axis=1) - nof_samples//2) * (timestep/upsample_factor)
+            pulse_timings_per_pol = (np.argmax(signals_upsampled, axis=1) - nof_samples // 2) * (
+                        timestep / upsample_factor)
 
-        #pulse_timings = np.argmax(hilbert_envelope[:, :, 1], axis=1) * (timestep/upsample_factor)
         if self.verbose:
             print('Timings done')
 
         if do_hilbert_envelope and sum_over_pol:
-            pulse_timings_per_pol = np.zeros( (Nant, Npols) )
+            pulse_timings_per_pol = np.zeros((Nant, Npols))
             for pol in range(Npols):
-                pulse_timings_per_pol[:, pol] += pulse_timings # want to do this without yucky for loop
+                pulse_timings_per_pol[:, pol] += pulse_timings  # want to do this without yucky for loop
 
         return pulse_timings_per_pol
 
-
-    def phase_wrap(self, phases):
+    @staticmethod
+    def phase_wrap(phases):
         """
         wrap 'phases' (float or any array shape) into interval (-pi, pi)
         """
-        return ((phases + np.pi) % (2 * np.pi) - np.pi)
+        return (phases + np.pi) % (2 * np.pi) - np.pi
 
     def timing_corrected_phases(self, freqs, phase_spectrum, pulse_timings):
         """
@@ -125,25 +133,27 @@ class interp2d_signal:
         (Nants, Nphases, Npols) = phase_spectrum.shape
 
         freq_step = freqs[1]
-        phase_spectrum_corrected = np.zeros( phase_spectrum.shape )
+        phase_spectrum_corrected = np.zeros(phase_spectrum.shape)
 
         for i, ant in enumerate(range(Nants)):
             for pol in range(Npols):
-
-                this_phase_corrections = 2*np.pi * (freqs*1.0e6) * pulse_timings[i, pol] # plus or minus sign?
-                phase_spectrum_corrected[ant, :, pol] = phase_spectrum[ant, :, pol] + this_phase_corrections # this can be done more efficiently...
+                this_phase_corrections = 2 * np.pi * (freqs * 1.0e6) * pulse_timings[i, pol]  # plus or minus sign?
+                phase_spectrum_corrected[ant, :, pol] = phase_spectrum[ant, :,
+                                                        pol] + this_phase_corrections  # this can be done more efficiently...
 
         # WRAP phases into 0..2*pi
         phase_spectrum_corrected = self.phase_wrap(phase_spectrum_corrected)
-        phase_spectrum_corrected = np.unwrap(phase_spectrum_corrected, axis=1, discont=0.7*np.pi)
+        phase_spectrum_corrected = np.unwrap(phase_spectrum_corrected, axis=1, discont=0.7 * np.pi)
         # needed?
 
         return phase_spectrum_corrected
 
-    def phase_unwrap_2d(self, x, y, phases):
+    @staticmethod
+    def phase_unwrap_2d(x, y, phases):
         """
         Basic method to unwrap phases in 2D
-        The general problem of optimal 2D phase unwrapping is NP-complete (see ref in article), so this will only work for well-behaved, slowly varying phases
+        The general problem of optimal 2D phase unwrapping is NP-complete (see ref in article),
+        so this will only work for well-behaved, slowly varying phases
         First do 1D unwrap over radial directions
         Then 1D unwrap over angular directions (along circles in the radial grid)
 
@@ -159,15 +169,14 @@ class interp2d_signal:
 
         # First along radial axis, then angular axis
         phases_unwrapped_2d = np.unwrap(phases_ordered, axis=0)
-        phases_unwrapped_2d  = np.unwrap(phases_unwrapped_2d, axis=1)
-        #phases_unwrapped_2d  = np.unwrap(phases_unwrapped_2d, axis=0)
+        phases_unwrapped_2d = np.unwrap(phases_unwrapped_2d, axis=1)
 
         # Back into original 1D shape...
-        phases_unwrapped = np.zeros( phases.shape )
+        phases_unwrapped = np.zeros(phases.shape)
 
         (Nradial, Nangular, Npol) = phases_unwrapped_2d.shape
 
-        phases_unwrapped[indices.ravel()] = phases_unwrapped_2d.reshape( (Nradial*Nangular, Npol) )
+        phases_unwrapped[indices.ravel()] = phases_unwrapped_2d.reshape((Nradial * Nangular, Npol))
 
         return phases_unwrapped
 
@@ -180,7 +189,7 @@ class interp2d_signal:
 
         spectrum_corrected = ampli * complex_phases
 
-        freq_range = np.where( (self.freqs > low_freq) & (self.freqs < high_freq))[0]
+        freq_range = np.where((self.freqs > low_freq) & (self.freqs < high_freq))[0]
 
         complex_sum = np.sum(spectrum_corrected[:, freq_range, :], axis=1)
 
@@ -202,7 +211,7 @@ class interp2d_signal:
 
         spectrum_corrected = ampli * complex_phases
 
-        freq_range = np.where( (self.freqs > low_freq) & (self.freqs < high_freq))[0]
+        freq_range = np.where((self.freqs > low_freq) & (self.freqs < high_freq))[0]
         complex_sum = np.sum(spectrum_corrected[:, freq_range, :], axis=1)
 
         const_phases = np.angle(complex_sum)
@@ -227,18 +236,18 @@ class interp2d_signal:
         high_freq : high frequency cutoff in MHz, default 500.0
         coherency_cutoff : threshold value for coherency level, default 0.8
         """
-        freq_indices = np.where( (self.freqs > low_freq) & (self.freqs < (high_freq)))[0] # high_freq - bandwidth?
+        freq_indices = np.where((self.freqs > low_freq) & (self.freqs < (high_freq)))[0]  # high_freq - bandwidth?
 
         (Nants, Nsamples, Npols) = self.phasespectrum_corrected.shape
-        coherency_vs_freq = np.zeros( (Nants, len(freq_indices), Npols))
+        coherency_vs_freq = np.zeros((Nants, len(freq_indices), Npols))
 
-        cutoff_freq = np.zeros( (Nants, Npols) )
+        cutoff_freq = np.zeros((Nants, Npols))
 
         for i, freq_index in enumerate(freq_indices):
             if self.verbose:
                 print('%d / %d' % (i, len(freq_indices)))
             this_freq = self.freqs[freq_index]
-            coherency = self.degree_of_coherency(low_freq=this_freq, high_freq=this_freq+bandwidth)
+            coherency = self.degree_of_coherency(low_freq=this_freq, high_freq=this_freq + bandwidth)
             coherency_vs_freq[:, i, :] = coherency
 
         # cutoff_values = np.where(coherency_vs_freq < 0.8)
@@ -246,19 +255,21 @@ class interp2d_signal:
         # do explicitly in for loops for now...
         for ant in range(Nants):
             for pol in range(Npols):
-                cutoff_index = np.where(coherency_vs_freq[ant, :, pol] < coherency_cutoff)[0] # first index where < 0.8
+                cutoff_index = np.where(coherency_vs_freq[ant, :, pol] < coherency_cutoff)[0]  # first index where < 0.8
                 if len(cutoff_index) > 0:
                     cutoff_index = cutoff_index[0]
                 else:
                     cutoff_index = -1
-                cutoff_freq[ant, pol] = min(self.freqs[freq_indices[cutoff_index]], high_freq) # max 500.0 cap, needed?
+                cutoff_freq[ant, pol] = min(self.freqs[freq_indices[cutoff_index]], high_freq)  # max 500.0 cap, needed?
 
-        return (coherency_vs_freq, cutoff_freq)
+        return coherency_vs_freq, cutoff_freq
 
-    def get_freq_dependent_timing_correction(self, lowfreq=30.0, highfreq=500.0, bandwidth=50.0, upsample_factor=10, ignore_cutoff_freq_in_timing=False):
+    def get_freq_dependent_timing_correction(self, lowfreq=30.0, highfreq=500.0, bandwidth=50.0, upsample_factor=10,
+                                             ignore_cutoff_freq_in_timing=False):
         """
         Implements "method (2)" to account for phase spectra towards higher frequencies.
-        Determines arrival time (E-field maximum) in a 50 MHz (or 'bandwidth') sliding frequency window, by filtering to each frequency window and inverse-FFT.
+        Determines arrival time (E-field maximum) in a 50 MHz (or 'bandwidth') sliding frequency window,
+        by filtering to each frequency window and inverse-FFT.
         Arrival time is mapped to phase in the center of each window.
 
         Parameters
@@ -269,36 +280,35 @@ class interp2d_signal:
         upsample_factor : upsampling factor for timing accuracy, default 10
         ignore_cutoff_freq_in_timing: proceed with pulse timing beyond cutoff frequency, default False
         """
-        start_freq = self.freqs[self.freqs>=lowfreq][0]
-        end_freq = self.freqs[self.freqs<=(highfreq+bandwidth/2)][-1]
+        start_freq = self.freqs[self.freqs >= lowfreq][0]
+        end_freq = self.freqs[self.freqs <= (highfreq + bandwidth / 2)][-1]
 
-        freq_indices = np.where((self.freqs >= lowfreq) & (self.freqs < (highfreq+bandwidth/2)))[0]
+        freq_indices = np.where((self.freqs >= lowfreq) & (self.freqs < (highfreq + bandwidth / 2)))[0]
 
         spectrum_after_correction_so_far = self.abs_spectrum * np.exp(1j * self.phasespectrum_corrected)
         signals = np.fft.irfft(spectrum_after_correction_so_far, axis=1)
 
-        freq_dependent_timing = np.zeros( self.abs_spectrum.shape )
+        freq_dependent_timing = np.zeros(self.abs_spectrum.shape)
 
         for i, freq_index in enumerate(freq_indices):
             if i % 3 != 0:
-                freq_dependent_timing[:, freq_index, :] += freq_dependent_timing[:, freq_index-1, :]
+                freq_dependent_timing[:, freq_index, :] += freq_dependent_timing[:, freq_index - 1, :]
             else:
                 this_freq = self.freqs[freq_index]
 
-                band_low = max(lowfreq, this_freq - bandwidth/2)
-                band_high = min(highfreq+bandwidth, this_freq + bandwidth/2)
-                #band_low = np.max(lowfreq, this_freq - bandwidth/2)
-                #band_high = min(highfreq+bandwidth/2, this_freq + bandwidth/2)
-                #band_low = max(lowfreq, band_high - bandwidth)
+                band_low = max(lowfreq, this_freq - bandwidth / 2)
+                band_high = min(highfreq + bandwidth, this_freq + bandwidth / 2)
+
                 if ((band_high - band_low) < bandwidth) and (band_low + bandwidth < band_high):
                     band_high = band_low + bandwidth
                 # check bandwidth
                 if self.verbose:
-                    print('Bandwidth %3.1f MHz, from %3.1f to %3.1f MHz' % (band_high-band_low, band_low, band_high))
+                    print('Bandwidth %3.1f MHz, from %3.1f to %3.1f MHz' % (band_high - band_low, band_low, band_high))
 
-                this_timing = self.hilbert_envelope_timing(signals, lowfreq=band_low, highfreq=band_high, upsample_factor=upsample_factor, do_hilbert_envelope=False)
+                this_timing = self.hilbert_envelope_timing(signals, lowfreq=band_low, highfreq=band_high,
+                                                           upsample_factor=upsample_factor, do_hilbert_envelope=False)
                 # returns timings for (Nant, Npol)
-                freq_dependent_timing[:, freq_index, :] += this_timing # check index broadcasting
+                freq_dependent_timing[:, freq_index, :] += this_timing  # check index broadcasting
 
         # do cutoff fixing here
         # keep timing constant beyond frequency cutoff
@@ -309,14 +319,15 @@ class interp2d_signal:
 
                     # Keep timing values constant for frequencies > local cutoff value
                     this_index = np.where(self.freqs >= self.cutoff_freq[ant, pol])[0][0]
-                    freq_dependent_timing[ant, this_index:, pol] = freq_dependent_timing[ant, this_index-1, pol]
+                    freq_dependent_timing[ant, this_index:, pol] = freq_dependent_timing[ant, this_index - 1, pol]
 
                     for i, index in enumerate(freq_indices):
                         if i == 0:
                             continue
                         # Just in case, a similar stopping criterion when successive timings get too `noisy`
-                        if np.abs(freq_dependent_timing[ant, index, pol] - freq_dependent_timing[ant, index-1, pol]) > 0.5e-9:
-                            freq_dependent_timing[ant, index:, pol] = freq_dependent_timing[ant, index-1, pol]
+                        if np.abs(freq_dependent_timing[ant, index, pol] - freq_dependent_timing[
+                            ant, index - 1, pol]) > 0.5e-9:
+                            freq_dependent_timing[ant, index:, pol] = freq_dependent_timing[ant, index - 1, pol]
                             break
 
         return freq_dependent_timing
@@ -335,17 +346,20 @@ class interp2d_signal:
         tolerance : tolerance in m for same_radius search
         """
         if not same_radius:
-            index = np.argmin( (self.pos_x - x)**2 + (self.pos_y - y)**2 )
-        else: # a bit convoluted...
-            radius_antennas = np.sqrt(self.pos_x**2 + self.pos_y**2)
-            thisradius = np.sqrt(x**2 + y**2)
+            index = np.argmin((self.pos_x - x) ** 2 + (self.pos_y - y) ** 2)
+        else:  # a bit convoluted...
+            radius_antennas = np.sqrt(self.pos_x ** 2 + self.pos_y ** 2)
+            thisradius = np.sqrt(x ** 2 + y ** 2)
 
-            indices_same_radius = np.where( (radius_antennas > (thisradius-tolerance)) & (radius_antennas < (thisradius+tolerance)) )[0]
+            indices_same_radius = np.where(
+                (radius_antennas > (thisradius - tolerance)) & (radius_antennas < (thisradius + tolerance))
+            )[0]
+
             assert len(indices_same_radius) > 0
             ant_x = self.pos_x[indices_same_radius]
             ant_y = self.pos_y[indices_same_radius]
 
-            index_min = np.argmin( (ant_x - x)**2 + (ant_y - y)**2 )
+            index_min = np.argmin((ant_x - x) ** 2 + (ant_y - y) ** 2)
 
             index = indices_same_radius[index_min]
 
@@ -363,7 +377,6 @@ class interp2d_signal:
         """
         return self.interpolators_cutoff_freq[pol](x, y)
 
-
     def __init__(self, x, y, signals, signals_start_times=None,
                  lowfreq=30.0, highfreq=500.0, sampling_period=0.1e-9, phase_method="phasor",
                  radial_method='cubic', upsample_factor=5, coherency_cutoff_threshold=0.9,
@@ -375,17 +388,24 @@ class interp2d_signal:
         ----------
         x : 1D array for the simulated antenna positions (x) in m
         y : idem for y
-        signals : 3D array of shape (Nant, Nsamples, Npols) with the antennas indexed in the first axis, the time traces in the second axis, and the polarizations in the third.
+        signals : 3D array of shape (Nant, Nsamples, Npols) with the antennas indexed in the first axis,
+        the time traces in the second axis, and the polarizations in the third.
         signals_start_times : np.ndarray, optional
             The absolute start times of the input traces, shaped as (Nant,)
-        lowfreq: low-frequency limit, typically set to 30 MHz. If a higher low-frequency limit is desired, it may likely be better to keep it at 30 MHz here, and high-pass filter later.
+        lowfreq: low-frequency limit, typically set to 30 MHz. If a higher low-frequency limit is desired,
+        it may likely be better to keep it at 30 MHz here, and high-pass filter later.
         highfreq : high-frequency limit, default 500.0 MHz, adjustable to e.g. 80 MHz.
         sampling_period : the time between samples in the data, default 0.1e-9 seconds (0.1 ns)
-        phase_method : the options for the phase interpolation are "phasor" and "timing", cf. pg 8 in the article ("Method (1)" vs "Method (2)"), default "phasor" (Method (1))
-        radial_method : the interp1d method used for radially interpolating Fourier coefficients. Usually set to 'cubic' for cubic splines, in interpolation_fourier.
+        phase_method : the options for the phase interpolation are "phasor" and "timing",
+        cf. pg 8 in the article ("Method (1)" vs "Method (2)"), default "phasor" (Method (1))
+        radial_method : the interp1d method used for radially interpolating Fourier coefficients.
+        Usually set to 'cubic' for cubic splines, in interpolation_fourier.
         upsample_factor : upsampling factor used for sub-sample timing accuracy. Default 5.
-        coherency_cutoff_threshold : the value of Eq. (2.4) that defines the reliable high-frequency limit on each position. Used internally in the "timing" method, also available to the user via self.get_cutoff_freq(x, y, pol) above. Default 0.9.
-        ignore_cutoff_freq_in_timing : can be set to True when experimenting with the "timing" method without its stopping criterion, default False.
+        coherency_cutoff_threshold : the value of Eq. (2.4) that defines the reliable high-frequency limit
+        on each position. Used internally in the "timing" method, also available to the user
+        via self.get_cutoff_freq(x, y, pol) above. Default 0.9.
+        ignore_cutoff_freq_in_timing : can be set to True when experimenting with the "timing" method without
+        its stopping criterion, default False.
         verbose : print info while initializing
         """
         self.nofcalls = 0
@@ -393,7 +413,7 @@ class interp2d_signal:
         self.method = phase_method
         self.pos_x = x
         self.pos_y = y
-        (Nants, Nsamples, Npols) = signals.shape # hard assumption, 3D...
+        (Nants, Nsamples, Npols) = signals.shape  # hard assumption, 3D...
         self.trace_length = Nsamples
         self.sampling_period = sampling_period
         if self.verbose: print('Setting sampling period to %1.1e seconds' % self.sampling_period)
@@ -404,7 +424,8 @@ class interp2d_signal:
             print('Doing timings using hilbert envelope...')
 
         # Get pulse timings using Hilbert envelope
-        self.pulse_timings = self.hilbert_envelope_timing(signals, lowfreq=30.0, highfreq=80.0, upsample_factor=upsample_factor)
+        self.pulse_timings = self.hilbert_envelope_timing(signals, lowfreq=30.0, highfreq=80.0,
+                                                          upsample_factor=upsample_factor)
 
         # Remove timings from phase spectra
         self.phasespectrum_corrected = self.timing_corrected_phases(self.freqs, self.phasespectrum, self.pulse_timings)
@@ -413,27 +434,43 @@ class interp2d_signal:
         self.const_phases = self.get_constant_phases(high_freq=80.0)
 
         # Remove phase constant from phase spectra
-        self.phasespectrum_corrected -= self.const_phases[:, np.newaxis, :] # from (Nant, Npol) to (Nant, Nsamples, Npol)
-        self.phasespectrum_corrected_before_freq_dependent = np.copy(self.phasespectrum_corrected) # for testing / demo purposes
+        self.phasespectrum_corrected -= self.const_phases[:, np.newaxis,
+                                        :]  # from (Nant, Npol) to (Nant, Nsamples, Npol)
+        self.phasespectrum_corrected_before_freq_dependent = np.copy(
+            self.phasespectrum_corrected)  # for testing / demo purposes
 
         # Get degree of coherency and reliable high-cutoff frequency
         if self.verbose:
             print('Getting coherency and freq cutoff')
-        (self.coherency_vs_freq, self.cutoff_freq) = self.get_coherency_vs_frequency(low_freq=lowfreq, high_freq=highfreq, coherency_cutoff=coherency_cutoff_threshold)
+
+        self.coherency_vs_freq, self.cutoff_freq = self.get_coherency_vs_frequency(
+            low_freq=lowfreq,
+            high_freq=highfreq,
+            coherency_cutoff=coherency_cutoff_threshold
+        )
+
         if self.method == "timing":
-            if verbose: print('Doing freq dependent timing...')
+            if verbose:
+                print('Doing freq dependent timing...')
+
             # Get arrival times in a sliding frequency window
-            self.freq_dependent_timing = self.get_freq_dependent_timing_correction(lowfreq=lowfreq, highfreq=highfreq, upsample_factor=upsample_factor, ignore_cutoff_freq_in_timing=ignore_cutoff_freq_in_timing)
-            if verbose: print('Done freq dependent timing')
+            self.freq_dependent_timing = self.get_freq_dependent_timing_correction(
+                lowfreq=lowfreq, highfreq=highfreq,
+                upsample_factor=upsample_factor,
+                ignore_cutoff_freq_in_timing=ignore_cutoff_freq_in_timing
+            )
+
+            if verbose:
+                print('Done freq dependent timing')
         else:
-            # print('NOT doing freq dependent timing')
             self.freq_dependent_timing = np.zeros(self.phasespectrum_corrected.shape)
 
         # Remove sliding-window timings from phase spectra
         for i, ant in enumerate(range(Nants)):
             for pol in range(Npols):
-                this_phase_corrections = 2*np.pi * (self.freqs*1.0e6) * self.freq_dependent_timing[ant, :, pol]
-                self.phasespectrum_corrected[ant, :, pol] = self.phasespectrum_corrected[ant, :, pol] + this_phase_corrections # this can be done more efficiently...
+                this_phase_corrections = 2 * np.pi * (self.freqs * 1.0e6) * self.freq_dependent_timing[ant, :, pol]
+                self.phasespectrum_corrected[ant, :, pol] = self.phasespectrum_corrected[ant, :,
+                                                            pol] + this_phase_corrections  # this can be done more efficiently...
 
         self.coherency = self.degree_of_coherency(low_freq=lowfreq, high_freq=highfreq)
 
@@ -442,18 +479,20 @@ class interp2d_signal:
         Do the Fourier interpolation for each frequency bin < 500 MHz, and for each polarization, separately
         Note: an order of magnitude speed improvement should be obtainable by vectorizing the Fourier interpolator
         """
-        nof_freq_channels = len(np.where( (self.freqs < highfreq) )[0])
+        nof_freq_channels = len(np.where((self.freqs < highfreq))[0])
 
-        self.interpolators_abs_spectrum = np.empty( (Npols, nof_freq_channels), dtype=object)# [ [None]*nof_freq_channels ] * Npols
+        self.interpolators_abs_spectrum = np.empty(
+            (Npols, nof_freq_channels), dtype=object
+        )  # [ [None]*nof_freq_channels ] * Npols
 
         """
         Create interpolators for the "phasors" for each frequency,
         i.e. exp(i phi(f)) = (cos(i phi), sin(i phi)) for each frequency
         """
-        self.interpolators_cosphi = np.empty( (Npols, nof_freq_channels), dtype=object)
-        self.interpolators_sinphi = np.empty( (Npols, nof_freq_channels), dtype=object)
+        self.interpolators_cosphi = np.empty((Npols, nof_freq_channels), dtype=object)
+        self.interpolators_sinphi = np.empty((Npols, nof_freq_channels), dtype=object)
 
-        self.interpolators_freq_dependent_timing = np.empty( (Npols, nof_freq_channels), dtype=object)
+        self.interpolators_freq_dependent_timing = np.empty((Npols, nof_freq_channels), dtype=object)
 
         self.interpolators_timing = np.empty(Npols, dtype=object)
 
@@ -461,17 +500,25 @@ class interp2d_signal:
 
         self.interpolators_cutoff_freq = np.empty(Npols, dtype=object)
 
-        if verbose: print('Creating %d interpolators total' % (3*Npols*nof_freq_channels + 3*Npols), end=' ')
+        if verbose:
+            print('Creating %d interpolators total' % (3 * Npols * nof_freq_channels + 3 * Npols), end=' ')
 
         # Create and initialize the interpolators for all quantities
         for freq_channel in range(nof_freq_channels):
             for pol in range(Npols):
-                self.interpolators_abs_spectrum[pol, freq_channel] = interpF.interp2d_fourier(x, y, self.abs_spectrum[:, freq_channel, pol])
-                self.interpolators_freq_dependent_timing[pol, freq_channel] = interpF.interp2d_fourier(x, y, self.freq_dependent_timing[:, freq_channel, pol])
+                self.interpolators_abs_spectrum[pol, freq_channel] = interpF.interp2d_fourier(
+                    x, y, self.abs_spectrum[:,freq_channel, pol]
+                )
+                self.interpolators_freq_dependent_timing[pol, freq_channel] = interpF.interp2d_fourier(
+                    x, y, self.freq_dependent_timing[:, freq_channel,pol]
+                )
 
-                self.interpolators_cosphi[pol, freq_channel] = interpF.interp2d_fourier(x, y, np.cos(self.phasespectrum_corrected[:, freq_channel, pol]) )
-                self.interpolators_sinphi[pol, freq_channel] = interpF.interp2d_fourier(x, y, np.sin(self.phasespectrum_corrected[:, freq_channel, pol]) )
-
+                self.interpolators_cosphi[pol, freq_channel] = interpF.interp2d_fourier(
+                    x, y, np.cos(self.phasespectrum_corrected[:, freq_channel, pol])
+                )
+                self.interpolators_sinphi[pol, freq_channel] = interpF.interp2d_fourier(
+                    x, y, np.sin(self.phasespectrum_corrected[:, freq_channel, pol])
+                )
 
         for pol in range(Npols):
             self.interpolators_timing[pol] = interpF.interp2d_fourier(x, y, self.pulse_timings[:, pol])
@@ -485,7 +532,6 @@ class interp2d_signal:
 
         if self.verbose:
             print('Done.')
-    # end __init__
 
     def __call__(self, x, y,
                  lowfreq=30.0, highfreq=500.0, filter_up_to_cutoff=False,
@@ -514,10 +560,6 @@ class interp2d_signal:
         full_output : bool, default=False
             Put this to True to retrieve arrival time and spectra, next to the signal traces.
         """
-        # if account_for_timing + return_arrival_times > 1:
-        #     raise ValueError(f'account_for_timing and  return_arrival_times are not compatible,'
-        #                      f'please select only one')
-
         if (self.nofcalls == 0) and self.verbose:
             print('Method: %s' % self.method)
         self.nofcalls += 1
@@ -526,37 +568,37 @@ class interp2d_signal:
         Npols = len(self.interpolators_abs_spectrum)
 
         freqs = np.fft.rfftfreq(self.trace_length, d=self.sampling_period)
-        freqs /= 1.0e6 # in MHz
-        ## Make self.freqs (todo)
+        freqs /= 1.0e6  # in MHz
+        # TODO: Make self.freqs
 
         # Set up reconstructed spectra, timings, phases at freq=0
-        abs_spectrum = np.zeros( (self.trace_length//2+1, Npols) )
-        phasespectrum = np.zeros( (self.trace_length//2+1, Npols) )
+        abs_spectrum = np.zeros((self.trace_length // 2 + 1, Npols))
+        phasespectrum = np.zeros((self.trace_length // 2 + 1, Npols))
         timings = np.zeros(Npols)
         const_phases = np.zeros(Npols)
 
         if self.method == 'timing':
             index_nearest = self.nearest_antenna_index(x, y)
-            print('pos x = %3.2f, y = %3.2f: nearest antenna at x = %3.2f, y = %3.2f m' % (x, y, self.pos_x[index_nearest], self.pos_y[index_nearest]))
+            print('pos x = %3.2f, y = %3.2f: nearest antenna at x = %3.2f, y = %3.2f m' % (
+                x, y, self.pos_x[index_nearest], self.pos_y[index_nearest])
+            )
 
-            phasespectrum = np.copy(self.phasespectrum_corrected[index_nearest]) # COPY !!!
+            phasespectrum = np.copy(self.phasespectrum_corrected[index_nearest])  # COPY !!!
             """
-            Do nearest-neighbor interpolation on remaining ('corrected') phases, which should be near zero, but do full interpolation on amplitude spectrum
+            Do nearest-neighbor interpolation on remaining ('corrected') phases, which should be near zero, 
+            but do full interpolation on amplitude spectrum
             """
             for freq_channel in range(Nfreqs):
-                for pol in range(Npols): # todo: reduce
+                for pol in range(Npols):  # TODO: reduce
                     thisPower = self.interpolators_abs_spectrum[pol, freq_channel](x, y)
-                    #thisPhase = self.interpolators_phase[pol, freq_channel](x, y)
                     abs_spectrum[freq_channel, pol] = thisPower
 
             # Account for freq dependent timings, which are interpolated first to (x, y)
             for freq_channel in range(Nfreqs):
                 for pol in range(Npols):
-
                     this_timing = self.interpolators_freq_dependent_timing[pol, freq_channel](x, y)
-                    this_phaseshift = -1.0e6*self.freqs[freq_channel] * 2*np.pi * this_timing
+                    this_phaseshift = -1.0e6 * self.freqs[freq_channel] * 2 * np.pi * this_timing
                     phasespectrum[freq_channel, pol] += this_phaseshift
-
 
         elif self.method == 'phasor':
             for freq_channel in range(Nfreqs):
@@ -566,7 +608,7 @@ class interp2d_signal:
                     this_realpart = self.interpolators_cosphi[pol, freq_channel](x, y)
                     this_imagpart = self.interpolators_sinphi[pol, freq_channel](x, y)
 
-                    thisPhase = np.angle(this_realpart + 1.0j*this_imagpart)
+                    thisPhase = np.angle(this_realpart + 1.0j * this_imagpart)
                     # making unit vector by dividing by abs(re**2 + im**2) and multiplying that may be significantly faster
 
                     abs_spectrum[freq_channel, pol] = thisPower
@@ -608,7 +650,7 @@ class interp2d_signal:
                 phase_shifts = -1.0e6 * freqs * 2 * np.pi * timings[pol]
                 phasespectrum[:, pol] += phase_shifts
             else:
-                phase_shifts = -1.0e6*freqs * 2*np.pi * const_time_offset
+                phase_shifts = -1.0e6 * freqs * 2 * np.pi * const_time_offset
                 phasespectrum[:, pol] += phase_shifts
 
             # Account for constant phase
@@ -617,13 +659,13 @@ class interp2d_signal:
         # Wrap into (-pi, pi) where needed, to tidy up
         phasespectrum = self.phase_wrap(phasespectrum)
         """
-        Set frequency channels with negative abs-amplitude to 0. This can arise sometimes when Fourier-interpolating abs-amplitudes around a circle. Throw warning when this is needed.
+        Set frequency channels with negative abs-amplitude to 0. This can arise sometimes when 
+        Fourier-interpolating abs-amplitudes around a circle. Throw warning when this is needed.
         """
         indices_negative = np.where(abs_spectrum < 0)
         nof_negative = len(indices_negative[0])
-        nof_negative_pol0 = len(np.where(indices_negative[1]==0)[0])
 
-        if (nof_negative > 0):
+        if nof_negative > 0:
             print('warning: negative values in abs_spectrum found: %d times. Setting to zero.' % nof_negative)
             abs_spectrum[indices_negative] = 0.0
         """
@@ -632,7 +674,7 @@ class interp2d_signal:
         for pol in range(Npols):
             high_cutoff = self.interpolators_cutoff_freq[pol](x, y) if filter_up_to_cutoff else highfreq
 
-            filter_indices = np.where( (freqs<lowfreq) | (freqs>high_cutoff))
+            filter_indices = np.where((freqs < lowfreq) | (freqs > high_cutoff))
             abs_spectrum[filter_indices, pol] *= 0.0
 
         # Produce reconstructed spectrum and time series

--- a/src/cr_pulse_interpolator/signal_interpolation_fourier.py
+++ b/src/cr_pulse_interpolator/signal_interpolation_fourier.py
@@ -558,17 +558,21 @@ class interp2d_signal:
         for freq_channel in range(nof_freq_channels):
             for pol in range(Npols):
                 self.interpolators_abs_spectrum[pol, freq_channel] = interpF.interp2d_fourier(
-                    x, y, self.abs_spectrum[:,freq_channel, pol]
+                    x, y, self.abs_spectrum[:, freq_channel, pol],
+                    radial_method=radial_method
                 )
                 self.interpolators_freq_dependent_timing[pol, freq_channel] = interpF.interp2d_fourier(
-                    x, y, self.freq_dependent_timing[:, freq_channel,pol]
+                    x, y, self.freq_dependent_timing[:, freq_channel, pol],
+                    radial_method=radial_method
                 )
 
                 self.interpolators_cosphi[pol, freq_channel] = interpF.interp2d_fourier(
-                    x, y, np.cos(self.phasespectrum_corrected[:, freq_channel, pol])
+                    x, y, np.cos(self.phasespectrum_corrected[:, freq_channel, pol]),
+                    radial_method=radial_method
                 )
                 self.interpolators_sinphi[pol, freq_channel] = interpF.interp2d_fourier(
-                    x, y, np.sin(self.phasespectrum_corrected[:, freq_channel, pol])
+                    x, y, np.sin(self.phasespectrum_corrected[:, freq_channel, pol]),
+                    radial_method=radial_method
                 )
 
         for pol in range(Npols):

--- a/src/cr_pulse_interpolator/signal_interpolation_fourier.py
+++ b/src/cr_pulse_interpolator/signal_interpolation_fourier.py
@@ -43,6 +43,10 @@ class interp2d_signal:
         the value of Eq. (2.4) that defines the reliable high-frequency limit
         on each position. Used internally in the "timing" method, also available to the user
         via self.get_cutoff_freq(x, y, pol) above.
+    allow_extrapolation : bool, default=True
+        if True, the interpolator will attempt to extrapolate the signal to outside the radius of the
+        input starshape. If set to False, calls to positions outside of the interpolation range will
+        return zero-traces, while positions at radii smaller than r_min will return the result at r_min.
     ignore_cutoff_freq_in_timing : bool, default=False
         can be set to True when experimenting with the "timing" method without its stopping criterion.
     verbose : bool, default=False
@@ -457,7 +461,7 @@ class interp2d_signal:
     def __init__(self, x, y, signals, signals_start_times=None,
                  lowfreq=30.0, highfreq=500.0, sampling_period=0.1e-9, phase_method="phasor",
                  radial_method='cubic', upsample_factor=5, coherency_cutoff_threshold=0.9,
-                 ignore_cutoff_freq_in_timing=False, verbose=False):
+                 allow_extrapolation=True, ignore_cutoff_freq_in_timing=False, verbose=False):
         self.nofcalls = 0
         self.verbose = verbose
         self.method = phase_method
@@ -466,7 +470,9 @@ class interp2d_signal:
         (Nants, Nsamples, Npols) = signals.shape  # hard assumption, 3D...
         self.trace_length = Nsamples
         self.sampling_period = sampling_period
-        if self.verbose: print('Setting sampling period to %1.1e seconds' % self.sampling_period)
+        if self.verbose:
+            print('Setting sampling period to %1.1e seconds' % self.sampling_period)
+
         # Get the abs-amplitude and phase spectra from the time traces
         (self.freqs, all_antennas_spectrum, self.abs_spectrum, self.phasespectrum, self.unwrapped_phases) = self.get_spectra(signals)
 
@@ -558,7 +564,7 @@ class interp2d_signal:
             for pol in range(Npols):
                 self.interpolators_abs_spectrum[pol, freq_channel] = interpF.interp2d_fourier(
                     x, y, self.abs_spectrum[:, freq_channel, pol],
-                    radial_method=radial_method, fill_value=None
+                    radial_method=radial_method, fill_value='extrapolate' if allow_extrapolation else None
                 )
                 self.interpolators_freq_dependent_timing[pol, freq_channel] = interpF.interp2d_fourier(
                     x, y, self.freq_dependent_timing[:, freq_channel, pol],


### PR DESCRIPTION
In the NRR implementation of the interpolator, we need to manually check whether we are outside of the valid range (ie the input range) to avoid issues with extrapolation. I think it makes more sense to make this a feature of this package instead.

In this PR, I have changed to implementation of the `fill_value` in interpolation_fourier.py, as was described in the docstring (but this was actually not how it was implemented before). This now allows to create an interpolator with bounds, which control the return value if a call outside the interpolation range is made.

Together with this, I added the `allow_extrapolation` parameter to the signal interpolator. The default for this parameter is currently `True`, as to not change the default behaviour. When set to `False`, the absolute frequency components are not longer extrapolated, but instead use the behaviour where they are kept constant when the requested radius is smaller than r_min, and are set to 0 when r goes above r_max.   