### PR TITLE
Fix time axis in demo (for now).

### DIFF
--- a/demo/demo_signal_interpolation.py
+++ b/demo/demo_signal_interpolation.py
@@ -70,7 +70,8 @@ for index in test_indices:
     (CC_zeroshift, CC_optimized_timeshift, delta_t, energy_rel_diff) = demo_helper.get_crosscorrelation(orig_pulse, interpolated_pulse)
     print('Normalized cross correlation (CC) = %1.4f, time mismatch = %1.3f ns' % (CC_zeroshift, delta_t))
 
-    demo_helper.plot_pulse_and_spectrum(orig_pulse, interpolated_pulse, this_x, this_y, this_cutoff_freq, pol)
+    time_axis = 0.1 * np.arange(4082) # TODO: use original and interpolated time axis  
+    demo_helper.plot_pulse_and_spectrum(time_axis, orig_pulse, time_axis, interpolated_pulse, this_x, this_y, this_cutoff_freq, pol)
 
 """
 Evaluate accuracy of arrival (start) time per antenna

--- a/demo/demo_signal_interpolation.py
+++ b/demo/demo_signal_interpolation.py
@@ -70,8 +70,12 @@ for index in test_indices:
     (CC_zeroshift, CC_optimized_timeshift, delta_t, energy_rel_diff) = demo_helper.get_crosscorrelation(orig_pulse, interpolated_pulse)
     print('Normalized cross correlation (CC) = %1.4f, time mismatch = %1.3f ns' % (CC_zeroshift, delta_t))
 
-    time_axis = 0.1 * np.arange(4082) # TODO: use original and interpolated time axis  
-    demo_helper.plot_pulse_and_spectrum(time_axis, orig_pulse, time_axis, interpolated_pulse, this_x, this_y, this_cutoff_freq, pol)
+    interpolated_time_axis = np.arange(len(interpolated_pulse)) * signal_interpolator.sampling_period + timings
+    demo_helper.plot_pulse_and_spectrum(
+        test_time_axis[index], orig_pulse,
+        interpolated_time_axis, interpolated_pulse,
+        this_x, this_y, this_cutoff_freq, pol
+    )
 
 """
 Evaluate accuracy of arrival (start) time per antenna


### PR DESCRIPTION
The previous merge broke the demo.
The demo_helper.plot_pulse_and_spectrum function now contains an original and interpolated time axis as required parameters.
Hmm, I don't think I added these myself?
I have fixed it for now by supplying it with one time axis.
The evaluation of the time axis accuracy is done separately anyway in a for loop below.
