### PR TITLE
Lower scipy version requirement

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cr_pulse_interpolator"
-version = "1.0.1"
+version = "1.1.1"
 authors = [
   { name="Arthur Corstanje", email="a.corstanje@astro.ru.nl" },
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,12 +1,12 @@
 [project]
 name = "cr_pulse_interpolator"
-version = "1.0.0"
+version = "1.0.1"
 authors = [
   { name="Arthur Corstanje", email="a.corstanje@astro.ru.nl" },
 ]
 description = "Full waveform interpolation for air shower simulations"
 readme = "README.md"
-requires-python = ">=3.6"
+requires-python = ">=3.7"
 classifiers = [
     "Programming Language :: Python :: 3",
     "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
@@ -14,7 +14,7 @@ classifiers = [
 ]
 dependencies = [
   'numpy >= 1.20',
-  'scipy >= 1.8',
+  'scipy >= 1.7',
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
Lowers the scipy version requirement to 1.7, and increases the Python version requirement to 3.7 (previously, scipy 1.8 already required Python>=3.8, see #20 ).

I have tested that all the demo examples run through successfully and produce sensible output on Python 3.7 / scipy 1.7.3. The motivation for lowering the scipy version requirement is that `cr-pulse-interpolator` is an (optional) dependency of NuRadioMC, which currently (tries to) support Python versions down to 3.7.

I have also bumped the version number to `1.0.1`, though oddly for some reason the pypi release is already version 1.1.0 - I don't know who's responsible for the pypi release but we may want to change the version number to be consistent.