### PR TITLE
Create workflow to publish on PyPi

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -44,7 +44,7 @@ jobs:
     needs:
       - release-build
     environment:
-      name: pypi
+      name: PyPi
       url: https://pypi.org/p/cr-pulse-interpolator
     permissions:
       id-token: write  # IMPORTANT: this permission is mandatory for trusted publishing

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -45,7 +45,7 @@ jobs:
       - release-build
     environment:
       name: pypi
-      url: https://pypi.org/p/<your-pypi-project-name>
+      url: https://pypi.org/p/cr-pulse-interpolator
     permissions:
       id-token: write  # IMPORTANT: this permission is mandatory for trusted publishing
     steps:

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -1,0 +1,61 @@
+# This workflow will upload a Python Package to PyPI when a release is created
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python#publishing-to-package-registries
+
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+name: Upload Python Package
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+
+jobs:
+  release-build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+
+      - name: Build release distributions
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install build
+          python -m build
+
+      - name: Upload distributions
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-dists
+          path: dist/
+
+  pypi-publish:
+    name: Upload release to PyPI
+    runs-on: ubuntu-latest
+    needs:
+      - release-build
+    environment:
+      name: pypi
+      url: https://pypi.org/p/<your-pypi-project-name>
+    permissions:
+      id-token: write  # IMPORTANT: this permission is mandatory for trusted publishing
+    steps:
+      - name: Retrieve release distributions
+        uses: actions/download-artifact@v4
+        with:
+          name: release-dists
+          path: dist/
+
+      - name: Publish release distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: dist/


### PR DESCRIPTION
I took the workflow file Github suggested and adapted it slightly to follow what the NuRadio repo does. The idea is to make a new PyPi release every time a new release is created here on the repo. I think this makes the most sense, as we do not have a `develop` or something similar to host intermediate changes before they get pushed to PyPi.