### PR TITLE
To merge branch 'turbo'

### DIFF
--- a/src/cr_pulse_interpolator/interpolation_fourier.py
+++ b/src/cr_pulse_interpolator/interpolation_fourier.py
@@ -117,7 +117,7 @@ class interp2d_fourier:
             if not recover_concentric_rings:
                 raise ValueError("Radius must be (approx.) constant along angular direction. "
                                  "You can try to \"fix\" that by using \"recover_concentric_rings=True\"")
-            else:
+            else: # TODO refactor to allow vectorized inputs with recover_concentric_rings==True !
                 self.radial_axis = np.mean(radius[ordering_indices], axis=1)
                 values_ordered_interpolated = []
                 for x, y in zip(radius[ordering_indices].T, values_ordered.T):
@@ -133,9 +133,7 @@ class interp2d_fourier:
         self.angular_FFT = np.fft.rfft(values_ordered, axis=1)
         length = values_ordered.shape[1]
         self.angular_FFT /= float(length)  # normalize
-        #import pdb; pdb.set_trace()
         # Produce interpolator function, interpolating the FFT components as a function of radius
-        #import pdb; pdb.set_trace()
 
         if fill_value is None:
             fill_value = (self.angular_FFT[0], np.zeros_like(self.angular_FFT[0]))
@@ -143,8 +141,8 @@ class interp2d_fourier:
             self.radial_axis, self.angular_FFT, axis=0, kind=radial_method, fill_value=fill_value, bounds_error=False
         )  # Interpolates the Fourier components along the radial axis
 
-        #import pdb; pdb.set_trace()
-    
+        return 
+
     def __call__(self, x, y, max_fourier_mode=None):
         """
         Interpolate the input used in __init__ for input positions (x, y)

--- a/src/cr_pulse_interpolator/interpolation_fourier.py
+++ b/src/cr_pulse_interpolator/interpolation_fourier.py
@@ -143,7 +143,7 @@ class interp2d_fourier:
             self.radial_axis, self.angular_FFT, axis=0, kind=radial_method, fill_value=fill_value, bounds_error=False
         )  # Interpolates the Fourier components along the radial axis
 
-        import pdb; pdb.set_trace()
+        #import pdb; pdb.set_trace()
     
     def __call__(self, x, y, max_fourier_mode=None):
         """

--- a/src/cr_pulse_interpolator/interpolation_fourier.py
+++ b/src/cr_pulse_interpolator/interpolation_fourier.py
@@ -117,14 +117,20 @@ class interp2d_fourier:
             if not recover_concentric_rings:
                 raise ValueError("Radius must be (approx.) constant along angular direction. "
                                  "You can try to \"fix\" that by using \"recover_concentric_rings=True\"")
-            else: # TODO refactor to allow vectorized inputs with recover_concentric_rings==True !
+            else: # TODO check behavior of recover_concentric_rings==True
                 self.radial_axis = np.mean(radius[ordering_indices], axis=1)
                 values_ordered_interpolated = []
-                for x, y in zip(radius[ordering_indices].T, values_ordered.T):
-                    intpf = intp.interp1d(
-                        x, y, axis=0, kind=radial_method, fill_value='extrapolate')
+                for radius_slice, values_slice in zip(np.moveaxis(radius[ordering_indices], 0, 1), np.moveaxis(values_ordered, 0, 1)):
+                    intpf = intp.interp1d(radius_slice, values_slice, axis=0, kind=radial_method, fill_value='extrapolate')
+
                     values_ordered_interpolated.append(intpf(self.radial_axis))
-                values_ordered = np.array(values_ordered_interpolated).T
+
+                    values_ordered = np.stack(values_ordered_interpolated, axis=1)
+                # for x, y in zip(radius[ordering_indices].T, values_ordered.T):
+                #     intpf = intp.interp1d(
+                #         x, y, axis=0, kind=radial_method, fill_value='extrapolate')
+                #     values_ordered_interpolated.append(intpf(self.radial_axis))
+                # values_ordered = np.array(values_ordered_interpolated).T
 
         self._value_shape = values_ordered.shape[2:] if values_ordered.ndim > 2 else ()
         self._n_value_dims = len(self._value_shape)

--- a/src/cr_pulse_interpolator/interpolation_fourier.py
+++ b/src/cr_pulse_interpolator/interpolation_fourier.py
@@ -64,21 +64,44 @@ class interp2d_fourier:
         return ordering_indices
 
     @classmethod
-    def cos_sin_components(cls, fourier):
+    def cos_sin_components(cls, fourier, n_value_dims=0):
         """
         Convert complex FFT as from np.fft.rfft to real-valued cos, sin components
-
-        Parameters
-        -----------
-        fourier : np.ndarray
-            complex Fourier components, with Fourier series running along the last axis.
         """
+
+        fourier_axis = -1 - n_value_dims
+
         cos_components = 2 * np.real(fourier)
-        cos_components[..., 0] *= 0.5
-        cos_components[..., -1] *= 0.5
         sin_components = -2 * np.imag(fourier)
 
+        # Index helpers
+        idx0 = [slice(None)] * cos_components.ndim
+        idxN = [slice(None)] * cos_components.ndim
+
+        idx0[fourier_axis] = 0
+        idxN[fourier_axis] = -1
+
+        cos_components[tuple(idx0)] *= 0.5
+        cos_components[tuple(idxN)] *= 0.5
+
         return cos_components, sin_components
+
+
+    # def cos_sin_components(cls, fourier):
+    #     """
+    #     Convert complex FFT as from np.fft.rfft to real-valued cos, sin components
+
+    #     Parameters
+    #     -----------
+    #     fourier : np.ndarray
+    #         complex Fourier components, with Fourier series running along the last axis.
+    #     """
+    #     cos_components = 2 * np.real(fourier)
+    #     cos_components[..., 0] *= 0.5
+    #     cos_components[..., -1] *= 0.5
+    #     sin_components = -2 * np.imag(fourier)
+
+    #     return cos_components, sin_components
 
     def __init__(self, x, y, values, radial_method='cubic', fill_value='extrapolate', recover_concentric_rings=False):
         # Convert (x, y) to (r, phi), make 2d position array, sorting positions and values by r and phi
@@ -103,12 +126,16 @@ class interp2d_fourier:
                     values_ordered_interpolated.append(intpf(self.radial_axis))
                 values_ordered = np.array(values_ordered_interpolated).T
 
+        self._value_shape = values_ordered.shape[2:] if values_ordered.ndim > 2 else ()
+        self._n_value_dims = len(self._value_shape)
+
         # FFT over the angular direction, for each radius
         self.angular_FFT = np.fft.rfft(values_ordered, axis=1)
-        length = values_ordered.shape[-1]
+        length = values_ordered.shape[1]
         self.angular_FFT /= float(length)  # normalize
-
+        #import pdb; pdb.set_trace()
         # Produce interpolator function, interpolating the FFT components as a function of radius
+        #import pdb; pdb.set_trace()
 
         if fill_value is None:
             fill_value = (self.angular_FFT[0], np.zeros_like(self.angular_FFT[0]))
@@ -116,6 +143,8 @@ class interp2d_fourier:
             self.radial_axis, self.angular_FFT, axis=0, kind=radial_method, fill_value=fill_value, bounds_error=False
         )  # Interpolates the Fourier components along the radial axis
 
+        import pdb; pdb.set_trace()
+    
     def __call__(self, x, y, max_fourier_mode=None):
         """
         Interpolate the input used in __init__ for input positions (x, y)
@@ -135,22 +164,50 @@ class interp2d_fourier:
 
         # Interpolate Fourier components over all values of radius
         fourier = self.interpolator_radius(radius)
-        fourier_len = fourier.shape[-1]
+        #fourier_len = fourier.shape[-1]
 
-        (cos_components, sin_components) = interp2d_fourier.cos_sin_components(fourier)
+        fourier_axis = -1 - self._n_value_dims
+        fourier_len = fourier.shape[fourier_axis]
+        print('boe')
+        print(fourier_len)
+        #import pdb; pdb.set_trace()
 
+        (cos_components, sin_components) = interp2d_fourier.cos_sin_components(fourier, self._n_value_dims)
+        print('bioe2')
         # Multipliers for Fourier modes, as k in cos(k*phi), sin(k*phi)
         limit = max_fourier_mode + 1 if max_fourier_mode is not None else fourier_len
         mult = np.linspace(0, limit - 1, limit).astype(int)
 
+        fourier_axis = -1 - self._n_value_dims 
+
+        angle = phi[..., None] * mult
+        angle = angle[(...,) + (None,) * self._n_value_dims]
+
+        result = np.sum(
+            cos_components[..., :limit] * np.cos(angle)
+            + sin_components[..., :limit] * np.sin(angle),
+            axis=fourier_axis
+        )
+
+
+        # angle = phi[..., None] * mult
+        # angle = angle[(...,) + (None,) * self._n_value_dims]
+        # print(angle) 
+        # result = np.sum(
+        #     cos_components[..., :limit, :] * np.cos(angle)
+        #     + sin_components[..., :limit, :] * np.sin(angle),
+        #     axis=1)
+
+
+
         # The Fourier sum done explicitly, as sum_k( c_k cos(k phi) + s_k sin(k phi) )
-        result = np.zeros_like(radius)
-        if isinstance(phi, float):
-            result += np.sum(cos_components[..., 0:limit] * np.cos(phi * mult))
-            result += np.sum(sin_components[..., 0:limit] * np.sin(phi * mult))
-        else:
-            result += np.sum(cos_components[..., 0:limit] * np.cos(phi[..., np.newaxis] * mult), axis=-1)
-            result += np.sum(sin_components[..., 0:limit] * np.sin(phi[..., np.newaxis] * mult), axis=-1)
+        # result = np.zeros_like(radius)
+        # if isinstance(phi, float):
+        #     result += np.sum(cos_components[..., 0:limit] * np.cos(phi * mult))
+        #     result += np.sum(sin_components[..., 0:limit] * np.sin(phi * mult))
+        # else:
+        #     result += np.sum(cos_components[..., 0:limit] * np.cos(phi[..., np.newaxis] * mult), axis=-1)
+        #     result += np.sum(sin_components[..., 0:limit] * np.sin(phi[..., np.newaxis] * mult), axis=-1)
 
         return result
 

--- a/src/cr_pulse_interpolator/interpolation_fourier.py
+++ b/src/cr_pulse_interpolator/interpolation_fourier.py
@@ -75,14 +75,14 @@ class interp2d_fourier:
         sin_components = -2 * np.imag(fourier)
 
         # Index helpers
-        idx0 = [slice(None)] * cos_components.ndim
-        idxN = [slice(None)] * cos_components.ndim
+        index0 = [slice(None)] * cos_components.ndim
+        indexN = [slice(None)] * cos_components.ndim
 
-        idx0[fourier_axis] = 0
-        idxN[fourier_axis] = -1
+        index0[fourier_axis] = 0
+        indexN[fourier_axis] = -1
 
-        cos_components[tuple(idx0)] *= 0.5
-        cos_components[tuple(idxN)] *= 0.5
+        cos_components[tuple(index0)] *= 0.5
+        cos_components[tuple(indexN)] *= 0.5
 
         return cos_components, sin_components
 
@@ -168,12 +168,9 @@ class interp2d_fourier:
 
         fourier_axis = -1 - self._n_value_dims
         fourier_len = fourier.shape[fourier_axis]
-        print('boe')
-        print(fourier_len)
-        #import pdb; pdb.set_trace()
-
+        
         (cos_components, sin_components) = interp2d_fourier.cos_sin_components(fourier, self._n_value_dims)
-        print('bioe2')
+        
         # Multipliers for Fourier modes, as k in cos(k*phi), sin(k*phi)
         limit = max_fourier_mode + 1 if max_fourier_mode is not None else fourier_len
         mult = np.linspace(0, limit - 1, limit).astype(int)
@@ -184,8 +181,8 @@ class interp2d_fourier:
         angle = angle[(...,) + (None,) * self._n_value_dims]
 
         result = np.sum(
-            cos_components[..., :limit] * np.cos(angle)
-            + sin_components[..., :limit] * np.sin(angle),
+            cos_components[..., 0:limit] * np.cos(angle)
+            + sin_components[..., 0:limit] * np.sin(angle),
             axis=fourier_axis
         )
 

--- a/src/cr_pulse_interpolator/interpolation_fourier.py
+++ b/src/cr_pulse_interpolator/interpolation_fourier.py
@@ -184,31 +184,12 @@ class interp2d_fourier:
         angle = phi[..., None] * mult
         angle = angle[(...,) + (None,) * self._n_value_dims]
 
+        # The Fourier sum done explicitly, as sum_k( c_k cos(k phi) + s_k sin(k phi) )
         result = np.sum(
             cos_components[..., 0:limit] * np.cos(angle)
             + sin_components[..., 0:limit] * np.sin(angle),
             axis=fourier_axis
         )
-
-
-        # angle = phi[..., None] * mult
-        # angle = angle[(...,) + (None,) * self._n_value_dims]
-        # print(angle) 
-        # result = np.sum(
-        #     cos_components[..., :limit, :] * np.cos(angle)
-        #     + sin_components[..., :limit, :] * np.sin(angle),
-        #     axis=1)
-
-
-
-        # The Fourier sum done explicitly, as sum_k( c_k cos(k phi) + s_k sin(k phi) )
-        # result = np.zeros_like(radius)
-        # if isinstance(phi, float):
-        #     result += np.sum(cos_components[..., 0:limit] * np.cos(phi * mult))
-        #     result += np.sum(sin_components[..., 0:limit] * np.sin(phi * mult))
-        # else:
-        #     result += np.sum(cos_components[..., 0:limit] * np.cos(phi[..., np.newaxis] * mult), axis=-1)
-        #     result += np.sum(sin_components[..., 0:limit] * np.sin(phi[..., np.newaxis] * mult), axis=-1)
 
         return result
 

--- a/src/cr_pulse_interpolator/signal_interpolation_fourier.py
+++ b/src/cr_pulse_interpolator/signal_interpolation_fourier.py
@@ -798,8 +798,8 @@ class interp2d_signal:
         indices_negative = np.where(abs_spectrum < 0)
         nof_negative = len(indices_negative[0])
 
-        if nof_negative > 0:
-            #print('warning: negative values in abs_spectrum found: %d times. Setting to zero.' % nof_negative)
+        if nof_negative > 50:
+            print('warning: negative values in abs_spectrum found: %d times. Setting to zero.' % nof_negative)
             abs_spectrum[indices_negative] = 0.0
         """
         Filter to bandwidth up to local cutoff frequency if desired, otherwise up to high frequency limit

--- a/src/cr_pulse_interpolator/signal_interpolation_fourier.py
+++ b/src/cr_pulse_interpolator/signal_interpolation_fourier.py
@@ -540,10 +540,6 @@ class interp2d_signal:
         self.Nfreqs = nof_freq_channels
         self.Nfreqs_full = len(self.freqs)
 
-        #self.interpolators_abs_spectrum = np.empty(
-        #    (Npols, nof_freq_channels), dtype=object
-        #)  # [ [None]*nof_freq_channels ] * Npols
-
         self.interpolator_abs_spectrum = interpF.interp2d_fourier(
                     x, y, self.abs_spectrum[:, 0:nof_freq_channels, :],
                     radial_method=radial_method, fill_value='extrapolate' if allow_extrapolation else None
@@ -569,51 +565,15 @@ class interp2d_signal:
         Create interpolators for the "phasors" for each frequency,
         i.e. exp(i phi(f)) = (cos(i phi), sin(i phi)) for each frequency
         """
-        # self.interpolators_cosphi = np.empty((Npols, nof_freq_channels), dtype=object)
-        # self.interpolators_sinphi = np.empty((Npols, nof_freq_channels), dtype=object)
-
-        # self.interpolators_freq_dependent_timing = np.empty((Npols, nof_freq_channels), dtype=object)
-
-        #self.interpolators_timing = np.empty(Npols, dtype=object)
-
-        #self.interpolators_constphase = np.empty(Npols, dtype=object)
-
-        #self.interpolators_cutoff_freq = np.empty(Npols, dtype=object)
+        
 
         if verbose:
             print('Creating %d interpolators total' % (3 * Npols * nof_freq_channels + 3 * Npols), end=' ')
-
-        # Create and initialize the interpolators for all quantities
-        # for freq_channel in range(nof_freq_channels):
-        #     for pol in range(Npols):
-        #         #self.interpolators_abs_spectrum[pol, freq_channel] = interpF.interp2d_fourier(
-        #         #    x, y, self.abs_spectrum[:, freq_channel, pol],
-        #         #    radial_method=radial_method, fill_value='extrapolate' if allow_extrapolation else None
-        #         #)
-        #         # self.interpolators_freq_dependent_timing[pol, freq_channel] = interpF.interp2d_fourier(
-        #         #     x, y, self.freq_dependent_timing[:, freq_channel, pol],
-        #         #     radial_method=radial_method
-        #         # )
-
-        #         self.interpolators_cosphi[pol, freq_channel] = interpF.interp2d_fourier(
-        #             x, y, np.cos(self.phasespectrum_corrected[:, freq_channel, pol]),
-        #             radial_method=radial_method
-        #         )
-        #         self.interpolators_sinphi[pol, freq_channel] = interpF.interp2d_fourier(
-        #             x, y, np.sin(self.phasespectrum_corrected[:, freq_channel, pol]),
-        #             radial_method=radial_method
-        #         )
 
         # Interpolators that return array with dimension [pol]
         self.interpolator_timing = interpF.interp2d_fourier(x, y, self.pulse_timings)
         self.interpolator_constphase = interpF.interp2d_fourier(x, y, self.const_phases)
         self.interpolator_cutoff_freq = interpF.interp2d_fourier(x, y, self.cutoff_freq)
-
-
-        # for pol in range(Npols):
-        #     self.interpolators_timing[pol] = interpF.interp2d_fourier(x, y, self.pulse_timings[:, pol])
-        #     self.interpolators_constphase[pol] = interpF.interp2d_fourier(x, y, self.const_phases[:, pol])
-        #     self.interpolators_cutoff_freq[pol] = interpF.interp2d_fourier(x, y, self.cutoff_freq[:, pol])
 
         if signals_start_times is not None:
             self.interpolators_arrival_times = interpF.interp2d_fourier(x, y, signals_start_times)
@@ -660,8 +620,6 @@ class interp2d_signal:
         self.nofcalls += 1
 
         # change to self.Nfreqs, self.Npols
-        #Nfreqs = len(self.interpolators_abs_spectrum[0])
-        #Npols = len(self.interpolators_abs_spectrum)
         Nfreqs, Npols = self.Nfreqs, self.Npols # todo remove / change below
 
         freqs = np.fft.rfftfreq(self.trace_length, d=self.sampling_period)
@@ -685,22 +643,20 @@ class interp2d_signal:
             Do nearest-neighbor interpolation on remaining ('corrected') phases, which should be near zero, 
             but do full interpolation on amplitude spectrum
             """
-            for freq_channel in range(Nfreqs):
-                for pol in range(Npols):  # TODO: reduce
-                    thisPower = self.interpolators_abs_spectrum[pol, freq_channel](x, y)
-                    abs_spectrum[freq_channel, pol] = thisPower
+
+            abs_interpolated = self.interpolator_abs_spectrum(x, y)   # (Nfreqs, Npols)
+            abs_spectrum[0:Nfreqs, :] = abs_interpolated # only first Nfreqs frequencies!
 
             # Account for freq dependent timings, which are interpolated first to (x, y)
+
+            freq_dependent_timing = self.interpolators_freq_dependent_timing(x, y)
             for freq_channel in range(Nfreqs):
                 for pol in range(Npols):
-                    this_timing = self.interpolators_freq_dependent_timing[pol, freq_channel](x, y)
-                    this_phaseshift = -1.0e6 * self.freqs[freq_channel] * 2 * np.pi * this_timing
+                    #this_timing = self.interpolators_freq_dependent_timing[pol, freq_channel](x, y)
+                    this_phaseshift = -1.0e6 * self.freqs[freq_channel] * 2 * np.pi * freq_dependent_timing[freq_channel, pol]
                     phasespectrum[freq_channel, pol] += this_phaseshift
 
-        elif self.method == 'phasor':
-            #abs_spectrum = np.zeros((self.Nfreqs_full, Npols))
-            #phase_spectrum = np.zeros((self.Nfreqs_full, Npols))
-            
+        elif self.method == 'phasor': 
             abs_interpolated = self.interpolator_abs_spectrum(x, y)   # (Nfreqs, Npols)
             real_part = self.interpolator_cosphi(x, y)                 # (Nfreqs, Npols)
             imag_part = self.interpolator_sinphi(x, y)                 # (Nfreqs, Npols)
@@ -712,19 +668,6 @@ class interp2d_signal:
             phasespectrum[0:Nfreqs, :] = np.arctan2(imag_part, real_part)
             # faster than np.angle, apparently, no complex numbers created
             
-            # for freq_channel in range(Nfreqs):
-            #     for pol in range(Npols):
-            #         # Interpolate abs-amplitude spectrum and phasors
-            #         thisPower = self.interpolators_abs_spectrum[pol, freq_channel](x, y)
-            #         this_realpart = self.interpolators_cosphi[pol, freq_channel](x, y)
-            #         this_imagpart = self.interpolators_sinphi[pol, freq_channel](x, y)
-
-            #         thisPhase = np.angle(this_realpart + 1.0j * this_imagpart)
-            #         # making unit vector by dividing by abs(re**2 + im**2) and multiplying that may be significantly faster
-
-            #         abs_spectrum[freq_channel, pol] = thisPower
-            #         phasespectrum[freq_channel, pol] = thisPhase
-
         else:
             raise ValueError('Unknown reconstruction method: %s' % self.method)
 
@@ -768,27 +711,7 @@ class interp2d_signal:
 
         # Constant phase
         phasespectrum += const_phases[None, :]
-
-
-        # for pol in range(Npols):
-        #     timings[pol] = self.interpolators_timing[pol](x, y)
-        #     const_phases[pol] = self.interpolators_constphase[pol](x, y)
-        #     # Account for timing
-        #     if pulse_centered:
-        #         # move pulse to the center of the trace
-        #         time_delta = self.trace_length * 0.5 * self.sampling_period
-        #         phase_shifts = -1.0e6 * freqs * 2 * np.pi * time_delta
-        #         phasespectrum[:, pol] += phase_shifts
-        #     if account_for_timing:
-        #         phase_shifts = -1.0e6 * freqs * 2 * np.pi * timings[pol]
-        #         phasespectrum[:, pol] += phase_shifts
-        #     else:
-        #         phase_shifts = -1.0e6 * freqs * 2 * np.pi * const_time_offset
-        #         phasespectrum[:, pol] += phase_shifts
-
-        #     # Account for constant phase
-        #     phasespectrum[:, pol] += const_phases[pol]
-
+        
         # Wrap into (-pi, pi) where needed, to tidy up
         phasespectrum = self.phase_wrap(phasespectrum)
         """

--- a/src/cr_pulse_interpolator/signal_interpolation_fourier.py
+++ b/src/cr_pulse_interpolator/signal_interpolation_fourier.py
@@ -799,7 +799,7 @@ class interp2d_signal:
         nof_negative = len(indices_negative[0])
 
         if nof_negative > 0:
-            print('warning: negative values in abs_spectrum found: %d times. Setting to zero.' % nof_negative)
+            #print('warning: negative values in abs_spectrum found: %d times. Setting to zero.' % nof_negative)
             abs_spectrum[indices_negative] = 0.0
         """
         Filter to bandwidth up to local cutoff frequency if desired, otherwise up to high frequency limit

--- a/src/cr_pulse_interpolator/signal_interpolation_fourier_OLD.py
+++ b/src/cr_pulse_interpolator/signal_interpolation_fourier_OLD.py
@@ -462,6 +462,7 @@ class interp2d_signal:
                  radial_method='cubic', upsample_factor=5, coherency_cutoff_threshold=0.9,
                  allow_extrapolation=True, ignore_cutoff_freq_in_timing=False, verbose=False):
 
+        print('Running OLD version of signal_interpolation_fourier')
         self.nofcalls = 0
         self.verbose = verbose
         self.method = phase_method
@@ -731,7 +732,7 @@ class interp2d_signal:
         nof_negative = len(indices_negative[0])
 
         if nof_negative > 0:
-            print('warning: negative values in abs_spectrum found: %d times. Setting to zero.' % nof_negative)
+            #print('warning: negative values in abs_spectrum found: %d times. Setting to zero.' % nof_negative)
             abs_spectrum[indices_negative] = 0.0
         """
         Filter to bandwidth up to local cutoff frequency if desired, otherwise up to high frequency limit

--- a/src/cr_pulse_interpolator/signal_interpolation_fourier_OLD.py
+++ b/src/cr_pulse_interpolator/signal_interpolation_fourier_OLD.py
@@ -455,7 +455,7 @@ class interp2d_signal:
         pol : int
             polarization number (single value)
         """
-        return self.interpolator_cutoff_freq(x, y)[pol] # check?
+        return self.interpolators_cutoff_freq[pol](x, y)
 
     def __init__(self, x, y, signals, signals_start_times=None,
                  lowfreq=30.0, highfreq=500.0, sampling_period=0.1e-9, phase_method="phasor",
@@ -468,7 +468,6 @@ class interp2d_signal:
         self.pos_x = x
         self.pos_y = y
         (Nants, Nsamples, Npols) = signals.shape  # hard assumption, 3D...
-        self.Npols = Npols 
         self.trace_length = Nsamples
         self.sampling_period = sampling_period
         if self.verbose:
@@ -537,83 +536,54 @@ class interp2d_signal:
         Note: an order of magnitude speed improvement should be obtainable by vectorizing the Fourier interpolator
         """
         nof_freq_channels = len(np.where((self.freqs < highfreq))[0])
-        self.Nfreqs = nof_freq_channels
-        self.Nfreqs_full = len(self.freqs)
 
-        #self.interpolators_abs_spectrum = np.empty(
-        #    (Npols, nof_freq_channels), dtype=object
-        #)  # [ [None]*nof_freq_channels ] * Npols
-
-        self.interpolator_abs_spectrum = interpF.interp2d_fourier(
-                    x, y, self.abs_spectrum[:, 0:nof_freq_channels, :],
-                    radial_method=radial_method, fill_value='extrapolate' if allow_extrapolation else None
-                )
-
-        self.interpolators_freq_dependent_timing = interpF.interp2d_fourier(
-                    x, y, self.freq_dependent_timing[:, 0:nof_freq_channels, :],
-                    radial_method=radial_method
-                )
-
-        self.interpolator_cosphi = interpF.interp2d_fourier(
-                    x, y, np.cos(self.phasespectrum_corrected[:, 0:nof_freq_channels, :]),
-                    radial_method=radial_method
-                )
-        self.interpolator_sinphi = interpF.interp2d_fourier(
-                    x, y, np.sin(self.phasespectrum_corrected[:, 0:nof_freq_channels, :]),
-                    radial_method=radial_method
-                )
-
-
+        self.interpolators_abs_spectrum = np.empty(
+            (Npols, nof_freq_channels), dtype=object
+        )  # [ [None]*nof_freq_channels ] * Npols
 
         """
         Create interpolators for the "phasors" for each frequency,
         i.e. exp(i phi(f)) = (cos(i phi), sin(i phi)) for each frequency
         """
-        # self.interpolators_cosphi = np.empty((Npols, nof_freq_channels), dtype=object)
-        # self.interpolators_sinphi = np.empty((Npols, nof_freq_channels), dtype=object)
+        self.interpolators_cosphi = np.empty((Npols, nof_freq_channels), dtype=object)
+        self.interpolators_sinphi = np.empty((Npols, nof_freq_channels), dtype=object)
 
-        # self.interpolators_freq_dependent_timing = np.empty((Npols, nof_freq_channels), dtype=object)
+        self.interpolators_freq_dependent_timing = np.empty((Npols, nof_freq_channels), dtype=object)
 
-        #self.interpolators_timing = np.empty(Npols, dtype=object)
+        self.interpolators_timing = np.empty(Npols, dtype=object)
 
-        #self.interpolators_constphase = np.empty(Npols, dtype=object)
+        self.interpolators_constphase = np.empty(Npols, dtype=object)
 
-        #self.interpolators_cutoff_freq = np.empty(Npols, dtype=object)
+        self.interpolators_cutoff_freq = np.empty(Npols, dtype=object)
 
         if verbose:
             print('Creating %d interpolators total' % (3 * Npols * nof_freq_channels + 3 * Npols), end=' ')
 
         # Create and initialize the interpolators for all quantities
-        # for freq_channel in range(nof_freq_channels):
-        #     for pol in range(Npols):
-        #         #self.interpolators_abs_spectrum[pol, freq_channel] = interpF.interp2d_fourier(
-        #         #    x, y, self.abs_spectrum[:, freq_channel, pol],
-        #         #    radial_method=radial_method, fill_value='extrapolate' if allow_extrapolation else None
-        #         #)
-        #         # self.interpolators_freq_dependent_timing[pol, freq_channel] = interpF.interp2d_fourier(
-        #         #     x, y, self.freq_dependent_timing[:, freq_channel, pol],
-        #         #     radial_method=radial_method
-        #         # )
+        for freq_channel in range(nof_freq_channels):
+            for pol in range(Npols):
+                self.interpolators_abs_spectrum[pol, freq_channel] = interpF.interp2d_fourier(
+                    x, y, self.abs_spectrum[:, freq_channel, pol],
+                    radial_method=radial_method, fill_value='extrapolate' if allow_extrapolation else None
+                )
+                self.interpolators_freq_dependent_timing[pol, freq_channel] = interpF.interp2d_fourier(
+                    x, y, self.freq_dependent_timing[:, freq_channel, pol],
+                    radial_method=radial_method
+                )
 
-        #         self.interpolators_cosphi[pol, freq_channel] = interpF.interp2d_fourier(
-        #             x, y, np.cos(self.phasespectrum_corrected[:, freq_channel, pol]),
-        #             radial_method=radial_method
-        #         )
-        #         self.interpolators_sinphi[pol, freq_channel] = interpF.interp2d_fourier(
-        #             x, y, np.sin(self.phasespectrum_corrected[:, freq_channel, pol]),
-        #             radial_method=radial_method
-        #         )
+                self.interpolators_cosphi[pol, freq_channel] = interpF.interp2d_fourier(
+                    x, y, np.cos(self.phasespectrum_corrected[:, freq_channel, pol]),
+                    radial_method=radial_method
+                )
+                self.interpolators_sinphi[pol, freq_channel] = interpF.interp2d_fourier(
+                    x, y, np.sin(self.phasespectrum_corrected[:, freq_channel, pol]),
+                    radial_method=radial_method
+                )
 
-        # Interpolators that return array with dimension [pol]
-        self.interpolator_timing = interpF.interp2d_fourier(x, y, self.pulse_timings)
-        self.interpolator_constphase = interpF.interp2d_fourier(x, y, self.const_phases)
-        self.interpolator_cutoff_freq = interpF.interp2d_fourier(x, y, self.cutoff_freq)
-
-
-        # for pol in range(Npols):
-        #     self.interpolators_timing[pol] = interpF.interp2d_fourier(x, y, self.pulse_timings[:, pol])
-        #     self.interpolators_constphase[pol] = interpF.interp2d_fourier(x, y, self.const_phases[:, pol])
-        #     self.interpolators_cutoff_freq[pol] = interpF.interp2d_fourier(x, y, self.cutoff_freq[:, pol])
+        for pol in range(Npols):
+            self.interpolators_timing[pol] = interpF.interp2d_fourier(x, y, self.pulse_timings[:, pol])
+            self.interpolators_constphase[pol] = interpF.interp2d_fourier(x, y, self.const_phases[:, pol])
+            self.interpolators_cutoff_freq[pol] = interpF.interp2d_fourier(x, y, self.cutoff_freq[:, pol])
 
         if signals_start_times is not None:
             self.interpolators_arrival_times = interpF.interp2d_fourier(x, y, signals_start_times)
@@ -659,10 +629,8 @@ class interp2d_signal:
             print('Method: %s' % self.method)
         self.nofcalls += 1
 
-        # change to self.Nfreqs, self.Npols
-        #Nfreqs = len(self.interpolators_abs_spectrum[0])
-        #Npols = len(self.interpolators_abs_spectrum)
-        Nfreqs, Npols = self.Nfreqs, self.Npols # todo remove / change below
+        Nfreqs = len(self.interpolators_abs_spectrum[0])
+        Npols = len(self.interpolators_abs_spectrum)
 
         freqs = np.fft.rfftfreq(self.trace_length, d=self.sampling_period)
         freqs /= 1.0e6  # in MHz
@@ -698,32 +666,18 @@ class interp2d_signal:
                     phasespectrum[freq_channel, pol] += this_phaseshift
 
         elif self.method == 'phasor':
-            #abs_spectrum = np.zeros((self.Nfreqs_full, Npols))
-            #phase_spectrum = np.zeros((self.Nfreqs_full, Npols))
-            
-            abs_interpolated = self.interpolator_abs_spectrum(x, y)   # (Nfreqs, Npols)
-            real_part = self.interpolator_cosphi(x, y)                 # (Nfreqs, Npols)
-            imag_part = self.interpolator_sinphi(x, y)                 # (Nfreqs, Npols)
+            for freq_channel in range(Nfreqs):
+                for pol in range(Npols):
+                    # Interpolate abs-amplitude spectrum and phasors
+                    thisPower = self.interpolators_abs_spectrum[pol, freq_channel](x, y)
+                    this_realpart = self.interpolators_cosphi[pol, freq_channel](x, y)
+                    this_imagpart = self.interpolators_sinphi[pol, freq_channel](x, y)
 
-            # Fill arrays
-            abs_spectrum[0:Nfreqs, :] = abs_interpolated # only first Nfreqs frequencies!
+                    thisPhase = np.angle(this_realpart + 1.0j * this_imagpart)
+                    # making unit vector by dividing by abs(re**2 + im**2) and multiplying that may be significantly faster
 
-            #phasespectrum[0:Nfreqs, :] = np.angle(re + 1j * im)
-            phasespectrum[0:Nfreqs, :] = np.arctan2(imag_part, real_part)
-            # faster than np.angle, apparently, no complex numbers created
-            
-            # for freq_channel in range(Nfreqs):
-            #     for pol in range(Npols):
-            #         # Interpolate abs-amplitude spectrum and phasors
-            #         thisPower = self.interpolators_abs_spectrum[pol, freq_channel](x, y)
-            #         this_realpart = self.interpolators_cosphi[pol, freq_channel](x, y)
-            #         this_imagpart = self.interpolators_sinphi[pol, freq_channel](x, y)
-
-            #         thisPhase = np.angle(this_realpart + 1.0j * this_imagpart)
-            #         # making unit vector by dividing by abs(re**2 + im**2) and multiplying that may be significantly faster
-
-            #         abs_spectrum[freq_channel, pol] = thisPower
-            #         phasespectrum[freq_channel, pol] = thisPhase
+                    abs_spectrum[freq_channel, pol] = thisPower
+                    phasespectrum[freq_channel, pol] = thisPhase
 
         else:
             raise ValueError('Unknown reconstruction method: %s' % self.method)
@@ -748,46 +702,24 @@ class interp2d_signal:
             # TODO: could make trace_start_time array of shape (Npol) and adjust each pol for timings?
 
         # Apply the 30-80 MHz arrival times and phase constants, each interpolated to (x, y) first
-        #timings = self.interpolator_timing(x, y)
-        #const_phases = self.interpolator_constphase(x, y)
+        for pol in range(Npols):
+            timings[pol] = self.interpolators_timing[pol](x, y)
+            const_phases[pol] = self.interpolators_constphase[pol](x, y)
+            # Account for timing
+            if pulse_centered:
+                # move pulse to the center of the trace
+                time_delta = self.trace_length * 0.5 * self.sampling_period
+                phase_shifts = -1.0e6 * freqs * 2 * np.pi * time_delta
+                phasespectrum[:, pol] += phase_shifts
+            if account_for_timing:
+                phase_shifts = -1.0e6 * freqs * 2 * np.pi * timings[pol]
+                phasespectrum[:, pol] += phase_shifts
+            else:
+                phase_shifts = -1.0e6 * freqs * 2 * np.pi * const_time_offset
+                phasespectrum[:, pol] += phase_shifts
 
-        # Interpolate per-pol quantities
-        timings = self.interpolator_timing(x, y)            # (Npols,)
-        const_phases = self.interpolator_constphase(x, y)   # (Npols,)
-
-        # Pulse centering
-        if pulse_centered:
-            time_delta = self.trace_length * 0.5 * self.sampling_period
-            phasespectrum += -1.0e6 * freqs[:, None] * 2 * np.pi * time_delta
-
-        # Timing correction
-        if account_for_timing:
-            phasespectrum += -1.0e6 * freqs[:, None] * 2 * np.pi * timings[None, :]
-        else:
-            phasespectrum += -1.0e6 * freqs[:, None] * 2 * np.pi * const_time_offset
-
-        # Constant phase
-        phasespectrum += const_phases[None, :]
-
-
-        # for pol in range(Npols):
-        #     timings[pol] = self.interpolators_timing[pol](x, y)
-        #     const_phases[pol] = self.interpolators_constphase[pol](x, y)
-        #     # Account for timing
-        #     if pulse_centered:
-        #         # move pulse to the center of the trace
-        #         time_delta = self.trace_length * 0.5 * self.sampling_period
-        #         phase_shifts = -1.0e6 * freqs * 2 * np.pi * time_delta
-        #         phasespectrum[:, pol] += phase_shifts
-        #     if account_for_timing:
-        #         phase_shifts = -1.0e6 * freqs * 2 * np.pi * timings[pol]
-        #         phasespectrum[:, pol] += phase_shifts
-        #     else:
-        #         phase_shifts = -1.0e6 * freqs * 2 * np.pi * const_time_offset
-        #         phasespectrum[:, pol] += phase_shifts
-
-        #     # Account for constant phase
-        #     phasespectrum[:, pol] += const_phases[pol]
+            # Account for constant phase
+            phasespectrum[:, pol] += const_phases[pol]
 
         # Wrap into (-pi, pi) where needed, to tidy up
         phasespectrum = self.phase_wrap(phasespectrum)
@@ -805,7 +737,7 @@ class interp2d_signal:
         Filter to bandwidth up to local cutoff frequency if desired, otherwise up to high frequency limit
         """
         for pol in range(Npols):
-            high_cutoff = self.interpolator_cutoff_freq(x, y)[pol] if filter_up_to_cutoff else highfreq
+            high_cutoff = self.interpolators_cutoff_freq[pol](x, y) if filter_up_to_cutoff else highfreq
 
             filter_indices = np.where((freqs < lowfreq) | (freqs > high_cutoff))
             abs_spectrum[filter_indices, pol] *= 0.0


### PR DESCRIPTION
Refactored interpolation_fourier.py to support ND-arrays of values for each position (x, y) on a star shape.
Refactored signal_interpolation_fourier.py to make use of vectorized interpolation_fourier.py.
Speed improvement factor ~ 80.
You still have to call the signal interpolator for one position (x, y) at a time.

It would be helpful as a double check if you convince yourself the demo gives exactly (or up to fp roundoff) the same results as in the old version.